### PR TITLE
[PERF] Optimize LingBot-World-Fast chunk profiling and runtime paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# uv
+uv.lock
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/telefuser/__init__.py
+++ b/telefuser/__init__.py
@@ -1,1 +1,6 @@
-from ._version import __version__
+try:
+    from ._version import __version__
+except ModuleNotFoundError as exc:
+    if exc.name != "telefuser._version":
+        raise
+    __version__ = "0.0.0+unknown"

--- a/telefuser/models/lingbot_world_fast_dit.py
+++ b/telefuser/models/lingbot_world_fast_dit.py
@@ -434,6 +434,7 @@ class LingBotWorldFastDiT(BaseModel):
         return control_tokens + hidden
 
     def patchify(self, x: torch.Tensor) -> tuple[torch.Tensor, tuple[int, int, int]]:
+        x = x.contiguous(memory_format=torch.channels_last_3d)
         x = self.patch_embedding(x)
         grid_size = x.shape[2:]
         return rearrange(x, "b c f h w -> b (f h w) c").contiguous(), grid_size

--- a/telefuser/models/lingbot_world_fast_dit.py
+++ b/telefuser/models/lingbot_world_fast_dit.py
@@ -17,6 +17,12 @@ from telefuser.utils.model_weight import init_weights_on_device, load_state_dict
 from .wan_video_dit import apply_rotary_emb, precompute_freqs_cis_3d, sinusoidal_embedding_1d
 
 
+def _cache_index_to_int(value: int | torch.Tensor) -> int:
+    if isinstance(value, int):
+        return value
+    return int(value.item())
+
+
 class CausalSelfAttention(nn.Module):
     """Causal self-attention with rolling KV cache support."""
 
@@ -90,7 +96,7 @@ class CausalSelfAttention(nn.Module):
         freqs_cos: torch.Tensor,
         freqs_sin: torch.Tensor,
         grid_size: tuple[int, int, int],
-        kv_cache: dict[str, torch.Tensor],
+        kv_cache: dict[str, torch.Tensor | int],
         current_start: int,
         max_attention_size: int,
     ) -> torch.Tensor:
@@ -111,8 +117,8 @@ class CausalSelfAttention(nn.Module):
         cache_k = kv_cache["k"]
         cache_v = kv_cache["v"]
         kv_cache_size = cache_k.shape[1]
-        global_end = int(kv_cache["global_end_index"].item())
-        local_end = int(kv_cache["local_end_index"].item())
+        global_end = _cache_index_to_int(kv_cache["global_end_index"])
+        local_end = _cache_index_to_int(kv_cache["local_end_index"])
 
         if self.local_attn_size != -1 and current_end > global_end and num_new_tokens + local_end > kv_cache_size:
             evicted = num_new_tokens + local_end - kv_cache_size
@@ -141,8 +147,8 @@ class CausalSelfAttention(nn.Module):
         out = F.scaled_dot_product_attention(q, k_cache, v_cache, is_causal=False)
         out = out.permute(0, 2, 1, 3).contiguous()
 
-        kv_cache["global_end_index"].fill_(current_end)
-        kv_cache["local_end_index"].fill_(local_end)
+        kv_cache["global_end_index"] = current_end
+        kv_cache["local_end_index"] = local_end
 
         out = rearrange(out, "b s n d -> b s (n d)")
         return self.o(out)
@@ -241,7 +247,7 @@ class LingBotWorldFastBlock(nn.Module):
         freqs_cos: torch.Tensor,
         freqs_sin: torch.Tensor,
         grid_size: tuple[int, int, int],
-        kv_cache: dict[str, torch.Tensor],
+        kv_cache: dict[str, torch.Tensor | int],
         crossattn_cache: dict[str, torch.Tensor | bool],
         current_start: int,
         max_attention_size: int,
@@ -458,7 +464,7 @@ class LingBotWorldFastDiT(BaseModel):
         context: torch.Tensor,
         y: torch.Tensor | None = None,
         control_tensor: torch.Tensor | None = None,
-        kv_cache: list[dict[str, torch.Tensor]] | None = None,
+        kv_cache: list[dict[str, torch.Tensor | int]] | None = None,
         crossattn_cache: list[dict[str, torch.Tensor | bool]] | None = None,
         current_start: int = 0,
         max_attention_size: int = 1_000_000,

--- a/telefuser/models/wan_video_vae.py
+++ b/telefuser/models/wan_video_vae.py
@@ -93,6 +93,7 @@ class CausalConv3d(nn.Conv3d):
             x = torch.cat([cache_x, x], dim=2)
             padding[4] -= cache_x.shape[2]
         x = F.pad(x, padding)
+        x = x.contiguous(memory_format=torch.channels_last_3d)
         return super().forward(x)
 
 

--- a/telefuser/ops/normalization.py
+++ b/telefuser/ops/normalization.py
@@ -160,9 +160,8 @@ class LayerNorm(CustomOp):
             return self.forward_native(x)
         if not self.elementwise_affine:
             return self.forward_native(x)
-
-        layer_norm_fn = _get_triton_kernel("layer_norm_fn")
-        return layer_norm_fn(x, self.weight, self.bias, eps=self.eps)
+        # Triton kernel in eager mode currently bring performance degradation
+        return self.forward_native(x)
 
     def forward_native(self, x: torch.Tensor) -> torch.Tensor:
         """PyTorch-native implementation for compile compatibility."""

--- a/telefuser/pipelines/lingbot_world_fast/denoising.py
+++ b/telefuser/pipelines/lingbot_world_fast/denoising.py
@@ -52,7 +52,7 @@ class LingBotWorldFastDenoisingStage:
         timesteps: torch.Tensor,
         scheduler: FlowUniPCMultistepScheduler,
         control_chunk: torch.Tensor | None,
-        self_kv_cache: list[dict[str, torch.Tensor]],
+        self_kv_cache: list[dict[str, torch.Tensor | int]],
         crossattn_cache: list[dict[str, torch.Tensor | bool]],
         current_start: int,
         max_attention_size: int,

--- a/telefuser/pipelines/lingbot_world_fast/pipeline.py
+++ b/telefuser/pipelines/lingbot_world_fast/pipeline.py
@@ -46,6 +46,8 @@ class LingBotWorldFastPipelineConfig:
     orig_height: int = 480
     orig_width: int = 832
     max_area: int = 480 * 832
+    local_attn_size: int = -1
+    sink_size: int = 0
 
 
 class LingBotWorldFastPipeline(BasePipeline):
@@ -104,12 +106,33 @@ class LingBotWorldFastPipeline(BasePipeline):
             str(fast_path),
             torch_dtype=config.dit_torch_dtype,
             control_type=config.control_type,
-            config={"patch_size": (1, 2, 2), "text_len": 512, "control_type": config.control_type},
+            config=self._build_dit_config(config),
         ).to(self.device)
         self.dit.eval().requires_grad_(False)
 
         self.denoise_stage = LingBotWorldFastDenoisingStage(self.dit, torch_dtype=self.torch_dtype)
         self.timesteps = LingBotWorldFastTimesteps()
+
+    @staticmethod
+    def _build_dit_config(config: LingBotWorldFastPipelineConfig) -> dict[str, object]:
+        return {
+            "patch_size": (1, 2, 2),
+            "text_len": 512,
+            "control_type": config.control_type,
+            "local_attn_size": int(config.local_attn_size),
+            "sink_size": int(config.sink_size),
+        }
+
+    @staticmethod
+    def _resolve_self_kv_size(
+        *,
+        frame_tokens: int,
+        latent_frames: int,
+        config: LingBotWorldFastPipelineConfig,
+    ) -> int:
+        if int(config.local_attn_size) > -1:
+            return int(frame_tokens) * int(config.local_attn_size)
+        return int(frame_tokens) * int(latent_frames)
 
     @torch.inference_mode()
     def encode_prompt(self, prompt: str) -> torch.Tensor:
@@ -417,7 +440,11 @@ class LingBotWorldFastPipeline(BasePipeline):
         frame_num = (lat_f - 1) * 4 + 1
         patch_area = self.dit.patch_size[1] * self.dit.patch_size[2]
         frame_tokens = (lat_h * lat_w) // patch_area
-        kv_size = frame_tokens * lat_f
+        kv_size = self._resolve_self_kv_size(
+            frame_tokens=frame_tokens,
+            latent_frames=lat_f,
+            config=self.config,
+        )
         max_seq_len = session_config.chunk_size * frame_tokens
         max_attention_size = (
             kv_size if session_config.max_attention_size is None else int(session_config.max_attention_size)

--- a/telefuser/pipelines/lingbot_world_fast/pipeline.py
+++ b/telefuser/pipelines/lingbot_world_fast/pipeline.py
@@ -209,15 +209,15 @@ class LingBotWorldFastPipeline(BasePipeline):
         kv_size: int,
         dtype: torch.dtype,
         device: str | torch.device,
-    ) -> list[dict[str, torch.Tensor]]:
+    ) -> list[dict[str, torch.Tensor | int]]:
         head_dim = self.dit.dim // self.dit.num_heads
         shape = (batch_size, kv_size, self.dit.num_heads, head_dim)
         return [
             {
                 "k": torch.zeros(shape, dtype=dtype, device=device),
                 "v": torch.zeros(shape, dtype=dtype, device=device),
-                "global_end_index": torch.tensor([0], dtype=torch.long, device=device),
-                "local_end_index": torch.tensor([0], dtype=torch.long, device=device),
+                "global_end_index": 0,
+                "local_end_index": 0,
             }
             for _ in range(self.dit.num_layers)
         ]

--- a/telefuser/pipelines/lingbot_world_fast/pipeline.py
+++ b/telefuser/pipelines/lingbot_world_fast/pipeline.py
@@ -20,6 +20,7 @@ from telefuser.models.wan_video_vae import WanVideoVAE
 from telefuser.schedulers.unipc import FlowUniPCMultistepScheduler
 from telefuser.utils.logging import logger
 from telefuser.utils.model_weight import load_state_dict
+from telefuser.utils.profiler import ProfilingContext4Debug
 
 from .control import (
     build_action_control_chunk,
@@ -370,6 +371,7 @@ class LingBotWorldFastPipeline(BasePipeline):
             )
         return control.control_tensor
 
+    @ProfilingContext4Debug("create_runtime")
     @torch.inference_mode()
     def create_runtime(
         self,
@@ -497,55 +499,59 @@ class LingBotWorldFastPipeline(BasePipeline):
             runtime.active = False
             return []
 
-        idx = runtime.current_chunk_index
-        latent_chunk = runtime.noise_chunks[idx]
-        condition_chunk = runtime.condition_chunks[idx]
-        control_chunk = control_override
-        if control_chunk is None and runtime.control_chunks is not None and idx < len(runtime.control_chunks):
-            control_chunk = runtime.control_chunks[idx]
+        with ProfilingContext4Debug("generate_next_chunk"):
+            idx = runtime.current_chunk_index
+            latent_chunk = runtime.noise_chunks[idx]
+            condition_chunk = runtime.condition_chunks[idx]
+            control_chunk = control_override
+            if control_chunk is None and runtime.control_chunks is not None and idx < len(runtime.control_chunks):
+                control_chunk = runtime.control_chunks[idx]
 
-        self._notify_progress(progress_callback, "denoising_chunk", index=idx)
-        current_start = idx * runtime.chunk_size * runtime.frame_tokens
-        denoised = self.denoise_stage.denoise_chunk(
-            latent_chunk=latent_chunk,
-            condition_chunk=condition_chunk,
-            prompt_emb=runtime.prompt_emb,
-            timesteps=runtime.timesteps,
-            scheduler=runtime.scheduler,
-            control_chunk=control_chunk,
-            self_kv_cache=runtime.self_kv_cache,
-            crossattn_cache=runtime.crossattn_cache,
-            current_start=current_start,
-            max_attention_size=runtime.max_attention_size,
-            generator=runtime.generator,
-        )
+            self._notify_progress(progress_callback, "denoising_chunk", index=idx)
+            current_start = idx * runtime.chunk_size * runtime.frame_tokens
+            with ProfilingContext4Debug("denoise_chunk"):
+                denoised = self.denoise_stage.denoise_chunk(
+                    latent_chunk=latent_chunk,
+                    condition_chunk=condition_chunk,
+                    prompt_emb=runtime.prompt_emb,
+                    timesteps=runtime.timesteps,
+                    scheduler=runtime.scheduler,
+                    control_chunk=control_chunk,
+                    self_kv_cache=runtime.self_kv_cache,
+                    crossattn_cache=runtime.crossattn_cache,
+                    current_start=current_start,
+                    max_attention_size=runtime.max_attention_size,
+                    generator=runtime.generator,
+                )
 
-        self._notify_progress(progress_callback, "updating_cache", index=idx)
-        self.dit(
-            x=denoised.to(dtype=self.torch_dtype),
-            timestep=torch.zeros((1,), dtype=torch.float32, device=self.device),
-            context=runtime.prompt_emb,
-            y=condition_chunk,
-            control_tensor=control_chunk,
-            kv_cache=runtime.self_kv_cache,
-            crossattn_cache=runtime.crossattn_cache,
-            current_start=current_start,
-            max_attention_size=runtime.max_attention_size,
-        )
+            self._notify_progress(progress_callback, "updating_cache", index=idx)
+            with ProfilingContext4Debug("kv_cache_update_forward"):
+                self.dit(
+                    x=denoised.to(dtype=self.torch_dtype),
+                    timestep=torch.zeros((1,), dtype=torch.float32, device=self.device),
+                    context=runtime.prompt_emb,
+                    y=condition_chunk,
+                    control_tensor=control_chunk,
+                    kv_cache=runtime.self_kv_cache,
+                    crossattn_cache=runtime.crossattn_cache,
+                    current_start=current_start,
+                    max_attention_size=runtime.max_attention_size,
+                )
 
-        self._notify_progress(progress_callback, "decoding_chunk", index=idx, device=str(self.vae_device))
-        frames = self.decode_video_cached(
-            denoised,
-            is_first_clip=(idx == 0),
-            is_last_clip=(idx == len(runtime.noise_chunks) - 1),
-        )
-        images = self.tensor2video(frames)
-        self._notify_progress(progress_callback, "chunk_decoded", index=idx, frames=len(images))
-        runtime.current_chunk_index += 1
-        runtime.emitted_frames += len(images)
-        if runtime.current_chunk_index >= len(runtime.noise_chunks):
-            runtime.active = False
-        return images
+            self._notify_progress(progress_callback, "decoding_chunk", index=idx, device=str(self.vae_device))
+            with ProfilingContext4Debug("vae_decode"):
+                frames = self.decode_video_cached(
+                    denoised,
+                    is_first_clip=(idx == 0),
+                    is_last_clip=(idx == len(runtime.noise_chunks) - 1),
+                )
+                images = self.tensor2video(frames)
+            self._notify_progress(progress_callback, "chunk_decoded", index=idx, frames=len(images))
+            runtime.current_chunk_index += 1
+            runtime.emitted_frames += len(images)
+            if runtime.current_chunk_index >= len(runtime.noise_chunks):
+                runtime.active = False
+            return images
 
     @staticmethod
     def encode_frames_to_b64(frames: list[Image.Image], quality: int = 85) -> list[str]:

--- a/telefuser/pipelines/lingbot_world_fast/service.py
+++ b/telefuser/pipelines/lingbot_world_fast/service.py
@@ -7,12 +7,13 @@ import queue
 import threading
 import time
 import uuid
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable
 
 import torch
 from PIL import Image, ImageDraw
 
 from telefuser.utils.logging import logger
+from telefuser.utils.profiler import ProfilingContext4Debug
 
 from .pipeline import LingBotWorldFastPipeline
 from .session import (
@@ -351,6 +352,15 @@ class LingBotWorldFastService:
             payload.update(data)
             self._put_output(state, payload)
 
+        with ProfilingContext4Debug("workloop"):
+            self._run_worker_loop(session_id, state, emit_status)
+
+    def _run_worker_loop(
+        self,
+        session_id: str,
+        state: LingBotWorldFastSessionState,
+        emit_status: Callable[..., None],
+    ) -> None:
         try:
             self._emit_preview_frame(state)
             emit_status("initializing_runtime")

--- a/telefuser/pipelines/lingbot_world_fast/session.py
+++ b/telefuser/pipelines/lingbot_world_fast/session.py
@@ -42,7 +42,7 @@ class LingBotWorldFastRuntimeState:
     condition_chunks: list[torch.Tensor]
     control_chunks: list[torch.Tensor] | None
     timesteps: torch.Tensor
-    self_kv_cache: list[dict[str, torch.Tensor]]
+    self_kv_cache: list[dict[str, torch.Tensor | int]]
     crossattn_cache: list[dict[str, torch.Tensor | bool]]
     latent_h: int
     latent_w: int

--- a/telefuser/utils/profiler.py
+++ b/telefuser/utils/profiler.py
@@ -15,6 +15,10 @@ Layer 2 (ON by env var):
     - Kernel categorization
     - Chrome trace visualization
     - Enable: ENABLE_PROFILER_NAMES=stage_name1,stage_name2
+    - Optional torch.profiler flags:
+      TELEFUSER_TORCH_PROFILER_RECORD_SHAPES=true|false
+      TELEFUSER_TORCH_PROFILER_PROFILE_MEMORY=true|false
+      TELEFUSER_TORCH_PROFILER_WITH_STACK=true|false
 
 Layer 3 (External tool):
     - ncu deep kernel analysis
@@ -176,6 +180,32 @@ def _should_enable_profiler(name: str) -> bool:
     if "*" in enabled_set:
         return True
     return name in enabled_set
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    """Read a boolean env var while preserving default behavior on unset/invalid values."""
+    value = os.getenv(name)
+    if value is None or value.strip() == "":
+        return default
+    normalized = value.strip().lower()
+    if normalized in ("1", "true", "yes", "on"):
+        return True
+    if normalized in ("0", "false", "no", "off"):
+        return False
+    logger.warning(f"[Profiler] Invalid boolean value for {name}={value!r}; using default {default}.")
+    return default
+
+
+def _get_torch_profiler_options() -> dict[str, bool]:
+    """Get configurable torch.profiler options.
+
+    Defaults intentionally match the historical TeleFuser profiler behavior.
+    """
+    return {
+        "record_shapes": _env_bool("TELEFUSER_TORCH_PROFILER_RECORD_SHAPES", True),
+        "profile_memory": _env_bool("TELEFUSER_TORCH_PROFILER_PROFILE_MEMORY", True),
+        "with_stack": _env_bool("TELEFUSER_TORCH_PROFILER_WITH_STACK", True),
+    }
 
 
 def _get_timing_report_path() -> str | None:
@@ -694,9 +724,7 @@ class _ProfilingContext:
 
             self._profiler = torch.profiler.profile(
                 activities=activities,
-                record_shapes=True,
-                profile_memory=True,
-                with_stack=True,
+                **_get_torch_profiler_options(),
             )
             self._profiler.start()
             logger.info(f"{self._rank_info} [Profiler] Started torch.profiler for '{self.name}'")

--- a/tests/unit/utils/test_profiler_flags.py
+++ b/tests/unit/utils/test_profiler_flags.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from telefuser.utils import profiler as profiler_module
+
+
+class _FakePlatform:
+    device_type = "cpu"
+
+    def synchronize(self) -> None:
+        pass
+
+
+class _FakeTorchProfiler:
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = kwargs
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def export_chrome_trace(self, path: str) -> None:
+        self.trace_path = path
+
+    def key_averages(self):
+        return []
+
+
+def test_torch_profiler_options_follow_env(monkeypatch, tmp_path) -> None:
+    profile_kwargs: list[dict] = []
+
+    def fake_profile(**kwargs):
+        profile_kwargs.append(kwargs)
+        return _FakeTorchProfiler(**kwargs)
+
+    monkeypatch.setenv("ENABLE_PROFILER_NAMES", "outer")
+    monkeypatch.setenv("TELEFUSER_PROFILER_OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setenv("TELEFUSER_TORCH_PROFILER_RECORD_SHAPES", "false")
+    monkeypatch.setenv("TELEFUSER_TORCH_PROFILER_PROFILE_MEMORY", "false")
+    monkeypatch.setenv("TELEFUSER_TORCH_PROFILER_WITH_STACK", "false")
+    monkeypatch.setattr(profiler_module, "current_platform", _FakePlatform())
+    monkeypatch.setattr(profiler_module.torch.profiler, "profile", fake_profile)
+    monkeypatch.setattr(profiler_module, "reset_peak_memory_stats", lambda: None)
+    monkeypatch.setattr(profiler_module, "capture_memory_snapshot", lambda: None)
+
+    context = profiler_module.ProfilingContext("outer")
+    context.__enter__()
+    assert context._profiler is not None
+    context._profiler.stop()
+
+    assert profile_kwargs[0]["record_shapes"] is False
+    assert profile_kwargs[0]["profile_memory"] is False
+    assert profile_kwargs[0]["with_stack"] is False
+
+
+def test_torch_profiler_options_preserve_existing_defaults(monkeypatch, tmp_path) -> None:
+    profile_kwargs: list[dict] = []
+
+    def fake_profile(**kwargs):
+        profile_kwargs.append(kwargs)
+        return _FakeTorchProfiler(**kwargs)
+
+    monkeypatch.setenv("ENABLE_PROFILER_NAMES", "outer")
+    monkeypatch.setenv("TELEFUSER_PROFILER_OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setattr(profiler_module, "current_platform", _FakePlatform())
+    monkeypatch.setattr(profiler_module.torch.profiler, "profile", fake_profile)
+    monkeypatch.setattr(profiler_module, "reset_peak_memory_stats", lambda: None)
+    monkeypatch.setattr(profiler_module, "capture_memory_snapshot", lambda: None)
+
+    context = profiler_module.ProfilingContext("outer")
+    context.__enter__()
+    assert context._profiler is not None
+    context._profiler.stop()
+
+    assert profile_kwargs[0]["record_shapes"] is True
+    assert profile_kwargs[0]["profile_memory"] is True
+    assert profile_kwargs[0]["with_stack"] is True


### PR DESCRIPTION

## Description

This PR adds finer-grained LingBot-World-Fast profiling controls and improves chunk generation performance by reducing avoidable layout conversions, removing eager Triton LayerNorm wrapper overhead, and avoiding CUDA scalar index synchronizations in the self-attention KV cache. It also exposes local attention window settings through the pipeline config so the runtime can size and use the self-KV cache according to the requested window.

## Motivation

Profiling showed several costs that were either hard to attribute or avoidable in the current LingBot-World-Fast runtime:

- Torch profiler defaults (`record_shapes`, `profile_memory`, `with_stack`) can add high overhead and distort pipeline-level traces.
- VAE `CausalConv3d` and DiT patch embedding receive NCDHW inputs while cuDNN Conv3d kernels prefer `channels_last_3d`; on current PyTorch/cuDNN this does not fall back to `slow_conv_dilated3d`, but it still triggers repeated implicit NCHW/NHWC layout transforms.
- The eager Triton LayerNorm path spends most of its apparent profiler time in Python/HOP/autotuner wrapper overhead rather than GPU compute.
- KV cache index tensors require `.item()` reads from CUDA tensors, introducing device-to-host synchronization.
- Local attention and sink-size settings need to flow from pipeline config into DiT/runtime cache sizing for profiling and generation experiments.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Other (please describe):

## Changes Made

- Profiling controls and trace ranges
  - Add env-driven torch profiler options:
    - `TELEFUSER_TORCH_PROFILER_RECORD_SHAPES`
    - `TELEFUSER_TORCH_PROFILER_PROFILE_MEMORY`
    - `TELEFUSER_TORCH_PROFILER_WITH_STACK`
  - Keep historical profiler defaults when env vars are unset or invalid.
  - Add `ProfilingContext4Debug` ranges for `workloop`, `create_runtime`, `generate_next_chunk`, `denoise_chunk`, `kv_cache_update_forward`, and `vae_decode`.

- LingBot-World-Fast local attention configuration
  - Add `local_attn_size` and `sink_size` to `LingBotWorldFastPipelineConfig`.
  - Pass those options into `LingBotWorldFastDiT.from_pretrained`.
  - Size the self-KV cache from the local attention window when `local_attn_size > -1`.

- Conv3d layout optimization
  - Convert DiT patch embedding input to `torch.channels_last_3d` before `self.patch_embedding`.
  - Convert `WanVideoVAE.CausalConv3d` input to `torch.channels_last_3d` before `nn.Conv3d.forward`.
  - This is not relying on `slow_conv_dilated3d` avoidance in the current environment. With torch `2.12.1+cu130` and cuDNN `9.20`, baseline already uses cuDNN Conv3d. The current gain comes from trading one explicit DtoD layout copy for many fewer implicit cuDNN NCHW/NHWC transforms.

- LayerNorm eager path
  - Route `LayerNorm.forward_cuda` to the native PyTorch implementation in eager mode.
  - This removes the profiler false hotspot caused by `torch.library.wrap_triton` / HOP / Triton autotuner wrapper cost on small LayerNorm kernels.

- KV cache index synchronization
  - Store `global_end_index` and `local_end_index` as host Python `int` values instead of CUDA tensors.
  - Keep a compatibility helper for existing tensor values, but update the runtime path to write ints.
  - This avoids `.item()`-driven DtoH syncs in `CausalSelfAttention.forward`.

- Packaging/import robustness
  - Add a fallback `__version__ = "0.0.0+unknown"` when `telefuser._version` is absent in a source checkout.

- Tests added
  - `tests/unit/utils/test_profiler_flags.py`

## Testing

- [x] Targeted unit tests pass
- [x] Manual testing performed
- [ ] Benchmarks added/updated (if applicable)

```bash
python -m pytest -q tests/unit/utils/test_profiler_flags.py
```

Result: passed, 2 tests.

## Checklist

- [ ] Code follows the project's coding standards (`ruff`)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] All tests pass (`pytest tests/`)
- [x] New tests added for new functionality
- [ ] Documentation updated (README, CLAUDE.md, docstrings)
- [ ] Commit messages are clear and descriptive
- [x] PR title follows the convention: `[TYPE] Brief description`

## Related Issues

N/A

## Additional Notes

- Earlier analysis identified an old-environment Conv3d issue where PyTorch `2.9.1` + cuDNN `9.10` could route bf16/fp16 5D Conv3d to `aten::slow_conv_dilated3d`. The current benchmark environment is different: torch `2.12.1+cu130`, CUDA `13.0`, cuDNN `9.20`, H100. In this environment, the baseline no longer goes through `slow_conv_dilated3d`; the observed VAE win is from reducing implicit layout transforms.

## GPU Architecture Support

- [ ] SM80 (Ampere, Ada Lovelace)
- [ ] SM90 (Hopper H100)
- [ ] SM100+ (Blackwell)

No new custom CUDA/Triton kernels are added. Runtime measurements in this draft were collected on NVIDIA H100 GPUs. The code changes use PyTorch memory-format and native operator paths, so there is no new architecture-specific kernel support matrix to validate.

## Performance Impact

Primary no-profiler benchmark:

- Config:
  - case `03`
  - `frame_num=201`
  - `chunk_size=3`
  - `local_attn_size=21`
  - `sink_size=3`
  - `max_area=399360`
  - `--no-write-video`
  - CUDA timing sync enabled
  - summary skips 1 warmup chunk and reports 16 steady-state chunks
- Environment:
  - torch `2.12.1+cu130`
  - CUDA `13.0`
  - cuDNN `9.20`
  - NVIDIA H100

| Metric | Baseline | Modified | Delta | Relative |
| --- | ---: | ---: | ---: | ---: |
| `generate_next_chunk_seconds.mean` | 2.932498 s | 2.862083 s | -0.070415 s/chunk | -2.40% |
| `denoise_seconds.mean` | 2.043713 s | 2.036162 s | -0.007551 s/chunk | -0.37% |
| `update_cache_seconds.mean` | 0.500482 s | 0.498508 s | -0.001974 s/chunk | -0.39% |
| `decode_seconds.mean` | 0.388245 s | 0.327375 s | -0.060869 s/chunk | -15.68% |
| `total_seconds.mean` | 2.932894 s | 2.862172 s | -0.070722 s/chunk | -2.41% |

At this resolution/config, decode accounts for roughly 86% of the steady-state `generate_next_chunk` improvement.

Profiler trace attribution:

- Config:
  - case `03`
  - `frame_num=89`
  - `chunk_size=3`
  - `local_attn_size=21`
  - `sink_size=3`
  - `max_area=99840`
  - profiler enabled for `create_runtime,generate_next_chunk`
- Important caveat: profiler-enabled `total_seconds` is dominated by profiler overhead. Use stage timing and GPU kernel attribution, not end-to-end profiler wall time.

Profiler timing summary:

| Metric | Baseline | Modified | Delta | Relative |
| --- | ---: | ---: | ---: | ---: |
| `generate_next_chunk_seconds.mean` | 1.024707 s | 0.625288 s | -0.399418 s/chunk | -38.98% |
| `denoise_seconds.mean` | 0.745963 s | 0.436910 s | -0.309053 s/chunk | -41.43% |
| `update_cache_seconds.mean` | 0.165109 s | 0.094973 s | -0.070136 s/chunk | -42.48% |
| `decode_seconds.mean` | 0.108267 s | 0.090073 s | -0.018194 s/chunk | -16.80% |

DiT GPU attribution from `analyze_telefuser_dit_profile.py`:

| Trace | Chosen GPU pid | Raw GPU time | Clean GPU time |
| --- | ---: | ---: | ---: |
| Baseline | 1 | 460.566 ms | 448.443 ms |
| Modified | 1 | 472.059 ms | 459.920 ms |

The DiT GPU kernel time is not the source of the current speedup in this trace.

VAE/GPU0 copy-layout attribution:

| Metric | Baseline | Modified | Delta |
| --- | ---: | ---: | ---: |
| GPU0 total kernel time | 86.184 ms | 74.733 ms | -11.451 ms (-13.29%) |
| layout/copy family, excluding host copies | ~27.16 ms | ~16.36 ms | ~-10.8 ms |
| `torch_direct_copy_kernel` | 14.641 ms / 434 launches | 8.782 ms / 263 launches | -5.859 ms |
| `cudnn_nchw_to_nhwc` | 7.561 ms / 207 launches | 0.351 ms / 12 launches | -7.210 ms |
| `cudnn_nhwc_to_nchw` | 3.392 ms / 105 launches | 0.158 ms / 6 launches | -3.234 ms |
| `Memcpy DtoD` | 0.447 ms / 70 launches | 5.950 ms / 350 launches | +5.503 ms |

Interpretation: the explicit `x.contiguous(memory_format=torch.channels_last_3d)` increases visible `Memcpy DtoD`, but it removes more implicit cuDNN NCHW/NHWC transforms and direct-copy work. This is why the modified branch can show higher `Memcpy DtoD` while still reducing total VAE decode time.

### Supplemental Trace Figures

The following profiler screenshots are included as supplementary evidence. The numeric benchmark tables above remain the source of truth for this PR.

Historical VAE Conv3d trace from the earlier PyTorch/cuDNN environment. This explains why the `channels_last_3d` change was originally investigated. It should not be read as the current torch `2.12.1+cu130` behavior, where baseline no longer falls back to `slow_conv_dilated3d`.

<img width="884" height="515" alt="image" src="https://github.com/user-attachments/assets/6860ba56-f7dd-40b1-ac5e-2c19055eb59f" />

Profiler-side `generate_next_chunk` / VAE timing view, showing the stage-level before/after context that motivated the VAE decode attribution.

<img width="844" height="540" alt="image" src="https://github.com/user-attachments/assets/764f1e74-27e9-429c-9826-52eb96df4456" />


LayerNorm profiler hotspot. The linked GPU kernel is only tens of microseconds, while the visible range is dominated by eager `wrap_triton` / HOP / autotuner wrapper cost.

<img width="471" height="667" alt="image" src="https://github.com/user-attachments/assets/fbe04d3c-3bdc-402e-9a26-1a6b6049cb16" />

LayerNorm fix context: route eager execution to the native PyTorch implementation instead of the small Triton wrapper path.

<img width="518" height="510" alt="image" src="https://github.com/user-attachments/assets/606afd3e-9d68-4bf3-9c27-45aea7913fba" />

KV cache index trace showing DtoH synchronization from reading CUDA scalar index tensors with `.item()`. The PR changes those indices to Python `int` values in the runtime path.

<img width="1428" height="932" alt="image" src="https://github.com/user-attachments/assets/b17b9086-4beb-4ab6-aee9-e6cfb8a179fe" />
