### PR TITLE
Enable Sequence Parallelism on FP8 Sol-Attn

### DIFF
--- a/benchmarks/fp8_sol_sequence_parallel/README.md
+++ b/benchmarks/fp8_sol_sequence_parallel/README.md
@@ -1,0 +1,81 @@
+# FP8 Sol-Attn Sequence-Parallel Tuning
+
+This microbenchmark isolates the per-rank FP8 Sol-Attn work after a Ulysses
+all-to-all. `local_heads = global_heads / sp_degree`; communication itself is
+covered by the distributed parity test rather than these kernel timings.
+
+Environment: NVIDIA H100 80 GB HBM3, PyTorch 2.11.0+cu128, seed 0, BF16 random
+Q/K/V, head dimension 128, warm CuTe specializations. Each reported value is the
+mean of three or ten CUDA-event measurements. These synthetic results tune
+execution parameters; they do not replace generated-video quality evaluation.
+
+## KV Splits
+
+`tau=1.0`, `threshold_type=diag`, 40 global heads:
+
+| Tokens | SP degree | Local heads | Split 1 kernel | Split 2 kernel | Split 4 kernel | Best |
+|---:|---:|---:|---:|---:|---:|---:|
+| 4,096 | 1 | 40 | 0.334 ms | 0.353 ms | 0.397 ms | 1 |
+| 4,096 | 4 | 10 | 0.279 ms | 0.302 ms | 0.315 ms | 1 |
+| 16,384 | 1 | 40 | 2.382 ms | 2.349 ms | 2.638 ms | 2 |
+| 16,384 | 4 | 10 | 0.696 ms | 0.693 ms | 0.749 ms | 2 |
+| 32,768 | 1 | 40 | 8.476 ms | 8.009 ms | 8.803 ms | 2 |
+| 32,768 | 4 | 10 | 2.254 ms | 2.089 ms | 2.226 ms | 2 |
+| 65,536 | 4 | 10 | - | 7.377 ms | 7.754 ms | 2 |
+
+The measurements support the existing FP8 `auto` boundary: split 1 below
+16,384 tokens and split 2 at or above it. Ulysses head sharding does not justify
+raising the split count. Split 4 regresses even at 65,536 tokens because its
+partial-output workspace and combine pass outweigh additional KV parallelism.
+
+The target Wan2.1 1.3B production shape has 32,760 tokens and 12 global heads.
+Ten-repeat measurements confirm the same split choice after head sharding:
+
+| SP degree | Local heads | Split 1 kernel | Split 2 kernel | Split 4 kernel | Best |
+|---:|---:|---:|---:|---:|---:|
+| 1 | 12 | 3.198 ms | 2.900 ms | 3.102 ms | 2 |
+| 2 | 6 | 1.662 ms | 1.501 ms | 1.594 ms | 2 |
+| 4 | 3 | 0.890 ms | 0.808 ms | 0.847 ms | 2 |
+
+## Routing Parameters
+
+At 16,384 tokens, SP=4, 10 local heads, split 2 (ten repetitions):
+
+| Tau | Threshold | Kernel | Quantize + kernel |
+|---:|---|---:|---:|
+| 0.5 | diag | 0.913 ms | 1.004 ms |
+| 0.5 | exact | 0.932 ms | 1.028 ms |
+| 1.0 | diag | 0.638 ms | 0.733 ms |
+| 1.0 | exact | 0.658 ms | 0.754 ms |
+| 1.5 | diag | 0.489 ms | 0.584 ms |
+| 1.5 | exact | 0.501 ms | 0.602 ms |
+
+Use `tau=1.0`, `diag`, and `kv_splits=auto` as the conservative production
+starting point. `tau=1.5` is an explicit aggressive profile: it was 23% faster
+than `tau=1.0` in this kernel test but selects fewer exact KV blocks and therefore
+requires model-level perceptual validation. `exact` was 2-3% slower here.
+
+## Reproduce
+
+```bash
+PYTHONPATH=. python tools/validation/benchmark_fp8_sol_attention.py \
+  --tokens 4096,16384,32768 \
+  --global-heads 40 --sp-degrees 1,4 \
+  --taus 1.0 --threshold-types diag \
+  --kv-splits 1,2,4 --warmup 1 --repeats 3 \
+  --output /tmp/fp8_sol_sp.json
+
+PYTHONPATH=. python tools/validation/benchmark_fp8_sol_attention.py \
+  --tokens 16384 --global-heads 40 --sp-degrees 4 \
+  --taus 0.5,1.0,1.5 --threshold-types diag,exact \
+  --kv-splits 2 --warmup 2 --repeats 10
+
+PYTHONPATH=. python tools/validation/benchmark_fp8_sol_attention.py \
+  --tokens 32760 --global-heads 12 --sp-degrees 1,2,4 \
+  --taus 1.0 --threshold-types diag \
+  --kv-splits 1,2,4 --warmup 2 --repeats 10
+```
+
+The corresponding NCCL correctness coverage is
+`tests/integration/test_wan_fp8_sol_distributed.py` for two- and four-way
+Ulysses execution.

--- a/docs/en/blog/fp8_sol_attention.md
+++ b/docs/en/blog/fp8_sol_attention.md
@@ -182,8 +182,9 @@ WGMMA Tensor Core instructions. Its FP8 path adds the following work to the upst
    channel scale is applied to the FP32 output accumulator after all PV contributions.
 6. **One online-softmax merge.** Exact and summary routes update the same row maxima, row sums, and output
    accumulator. The full attention matrix is never written to HBM.
-7. **Split-KV for long sequences.** On SM90, `auto` selects two splits for FP8 sequences at or above 16,384 tokens
-   and four splits at or above 65,536 tokens. A final log-sum-exp reduction merges the partial outputs.
+7. **Split-KV for long sequences.** On SM90, `auto` selects two splits for FP8 sequences at or above 16,384 tokens.
+   H100 measurements through 65,536 tokens show that four splits do not recover their additional workspace and
+   reduction cost. A final log-sum-exp reduction merges the two partial outputs.
 
 ```mermaid
 flowchart TB
@@ -224,8 +225,10 @@ prefix is registered as an exact KV sink, and prefix queries are recomputed with
 steps and first two DiT layers also use matched packed FlashAttention-4. Token-refiner attention remains dense.
 
 Unsupported shapes, dtypes, devices, or runtime kernel failures retain the public attention fallback. FP8 operands
-are dequantized before the BF16 fallback. Ring/USP attention remains dense because its online distributed merge needs
-log-sum-exp behavior outside the current Sol contract.
+are dequantized before the BF16 fallback. Pure Ulysses sequence parallelism is supported: its all-to-all first
+produces full-sequence, local-head Q/K/V, then each rank computes FP8 scales and runs Sol independently. Ring and
+combined Ulysses-ring attention remain dense because their distributed online merge needs log-sum-exp behavior
+outside the current Sol contract.
 
 ## Performance Results
 

--- a/docs/zh/blog/fp8_sol_attention.md
+++ b/docs/zh/blog/fp8_sol_attention.md
@@ -177,8 +177,9 @@ WGMMA Tensor Core。FP8 路径在 BF16 Sol 结构上增加以下工作：
    V channel scale 应用到 FP32 output accumulator。
 6. **统一 online-softmax merge**：exact 与 summary route 更新相同的 row max、row sum 和 output
    accumulator，不落盘完整 attention matrix。
-7. **长序列 Split-KV**：SM90 `auto` 策略在 FP8 序列长度达到 16,384 时选择两个 split，达到 65,536
-   时选择四个 split，最后通过 log-sum-exp reduction 合并部分结果。
+7. **长序列 Split-KV**：SM90 `auto` 策略在 FP8 序列长度达到 16,384 时选择两个 split。H100 实测覆盖
+   到 65,536 token，四个 split 仍无法抵消额外 workspace 与归约开销，因此保持两个 split，最后通过
+   log-sum-exp reduction 合并部分结果。
 
 ```mermaid
 flowchart TB
@@ -217,8 +218,9 @@ KV sink，prefix query 使用 BF16 dense attention 重新计算。前十个 step
 packed FlashAttention-4，token refiner 也始终保持 dense。
 
 不支持的 shape、dtype、device 或 kernel runtime failure 会保留公共 attention fallback。FP8 operand 会先
-反量化再进入 BF16 fallback。Ring/USP 仍走 dense，因为它的分布式 online merge 需要当前 Sol contract
-之外的 log-sum-exp 行为。
+反量化再进入 BF16 fallback。纯 Ulysses sequence parallel 已支持：all-to-all 先得到完整 sequence、局部
+head 的 Q/K/V，每个 rank 再独立计算 FP8 scale 并运行 Sol。Ring 以及 Ulysses-ring 组合仍走 dense，因为
+它们的分布式 online merge 需要当前 Sol contract 之外的 log-sum-exp 行为。
 
 ## 性能结果
 

--- a/examples/minimax_h3/README.md
+++ b/examples/minimax_h3/README.md
@@ -312,7 +312,7 @@ FlashAttention 4 is unavailable.
 
 ## Online DiT Quantization
 
-MiniMax H3 supports three single-GPU online quantization backends for the DiT transformer Linear layers:
+MiniMax H3 supports three online quantization backends for the DiT transformer Linear layers:
 
 | CLI value | Backend | Weight/activation path |
 |---|---|---|
@@ -323,8 +323,10 @@ MiniMax H3 supports three single-GPU online quantization backends for the DiT tr
 All three paths convert the 258 Linear layers in the main and token-refiner transformer blocks. The FP32 video/audio
 patch projections, timestep embedding, output projections, text encoder, and VAEs retain their reference dtypes.
 The BF16 DiT is loaded from the original shards, moved to CUDA after text encoding, quantized on first denoising use,
-and then kept resident for the pipeline lifetime. This ordering avoids a simultaneous BF16 text encoder and DiT on
-one GPU and avoids unsupported CPU transfers of quantized tensor subclasses.
+and then kept resident for the pipeline lifetime. In the multi-GPU tf-kernel FP8 profile, TP shards the BF16 Linear
+weights before each rank materializes its local FP8 weights; Ulysses then redistributes Q/K/V before their FP8 Sol
+quantization. This ordering avoids unsupported transfers of quantized tensor subclasses and preserves both parallel
+contracts.
 TorchAO and tf-kernel conversion have a transient memory peak near the BF16 footprint; use the full 80 GB device without colocated workloads.
 
 Use the single FL2VA example and choose the quantization backend with `--quantization`:
@@ -361,9 +363,9 @@ pipeline = load_minimax_h3_pipeline(
 )
 ~~~
 
-Online quantization currently requires ulysses_degree=1, tp_degree=1, and FSDP disabled. Quantizing before TP/FSDP
-would invalidate those wrappers' BF16 parameter-sharding contract, so unsupported combinations fail before checkpoint
-loading.
+TorchAO FP8 and bitsandbytes NF4 require ulysses_degree=1, tp_degree=1, and FSDP disabled. tf-kernel FP8 supports
+Ulysses sequence parallelism and tensor parallelism because conversion runs after TP sharding on every rank. Online
+quantization cannot be combined with FSDP.
 
 ### FP8 Sol-Attn
 
@@ -387,13 +389,23 @@ python -m examples.minimax_h3.minimax_h3_fl2va_h100 \
 
 # FP8 Linear + FP8 Sol attention
 python -m examples.minimax_h3.minimax_h3_fl2va_h100 \
-  --mode t2va --quantization fp8 --attn-impl SOL_ATTN --sol-fp8 \
+  --gpu-num 4 --mode t2va --quantization fp8 --attn-impl SOL_ATTN --sol-fp8 \
   --output outputs/h3_fp8_sol.mp4
 ~~~
 
 Use `--sol-dense-steps`, `--sol-dense-layers`, `--sol-tau`, `--sol-threshold-type`,
 `--sol-fp8-layer-start`, and `--sol-fp8-layer-end` to override the policy for controlled ablations. The defaults
 match the released H100 MiniMax-H3 Sol profile.
+
+For a warmed four-GPU comparison that saves synchronized MP4s, decoded arrays, throughput, and sampled device-memory
+peaks, run the two profiles below. Four GPUs use Ulysses2 x TP2 for both profiles.
+
+~~~bash
+python -m tools.validation.benchmark_minimax_h3_fp8_sol_sp \
+  --profile baseline --output benchmarks/minimax_h3_fp8_sol/baseline_sp2_tp2_bf16_flash.mp4
+python -m tools.validation.benchmark_minimax_h3_fp8_sol_sp \
+  --profile optimized --output benchmarks/minimax_h3_fp8_sol/optimized_sp2_tp2_fp8_sol_exact.mp4
+~~~
 
 For matched BF16/TorchAO-FP8/tf-kernel-FP8/NF4 profiling, use the validation benchmark. It writes the synchronized MP4 plus a JSON report
 containing load time, end-to-end generation time, stage timings, and denoising allocator peaks:

--- a/examples/minimax_h3/common.py
+++ b/examples/minimax_h3/common.py
@@ -208,8 +208,15 @@ def load_minimax_h3_pipeline(
     if (adaln_cache_path is not None or online_adaln_cache) and resolved_enable_fsdp:
         raise ValueError("AdaLN cache modes do not yet support FSDP deployment.")
     quant_config = minimax_h3_quant_config(quantization)
-    if quant_config.enabled and world_size != 1:
-        raise ValueError("MiniMax H3 online quantization currently requires a single-GPU profile")
+    supports_parallel_quantization = quant_config.quant_type == QuantType.FP8 and quant_config.kernel_backend in {
+        QuantKernelBackend.AUTO,
+        QuantKernelBackend.TF_KERNEL,
+    }
+    if quant_config.enabled and world_size != 1 and not supports_parallel_quantization:
+        raise ValueError(
+            "MiniMax H3 multi-GPU online quantization requires tf-kernel FP8; "
+            "TorchAO FP8 and bitsandbytes NF4 remain single-GPU only"
+        )
     if quant_config.enabled and resolved_enable_fsdp:
         raise ValueError("MiniMax H3 online quantization cannot be combined with FSDP")
     if isinstance(attn_impl, str):

--- a/examples/minimax_h3/minimax_h3_fl2va_h100.py
+++ b/examples/minimax_h3/minimax_h3_fl2va_h100.py
@@ -287,7 +287,7 @@ def _main(default_quantization: str | None = PPL_CONFIG["quantization"]) -> None
         "--quantization",
         choices=("fp8", "torchao-fp8", "tf-kernel-fp8", "bnb-nf4"),
         default=default_quantization,
-        help="Online DiT Linear quantization backend (single GPU only).",
+        help="Online DiT Linear quantization backend (tf-kernel FP8 supports SP/TP; other backends are single-GPU).",
     )
     parser.add_argument("--gpu-num", "--ulysses-degree", dest="gpu_num", type=int, choices=(1, 2, 4), default=1)
     parser.add_argument(

--- a/examples/wan_video/README.md
+++ b/examples/wan_video/README.md
@@ -236,6 +236,13 @@ python examples/wan_video/wan21_1_3b_text_to_video_optimized_h100.py \
     --tau 1.0 \
     --threshold-type diag \
     --kv-splits auto
+
+# Four-way Ulysses FP8 Sol. Use cfg-degree=2 to combine CFGP=2 and Ulysses=2.
+python examples/wan_video/wan21_1_3b_text_to_video_optimized_h100.py \
+    --model-root /path/to/Wan2.1-T2V-1.3B \
+    --parallelism 4 --cfg-degree 1 \
+    --attention fp8-sol --quantization tf-kernel-fp8 \
+    --fp8-layer-start 10 --fp8-layer-end 20
 ```
 
 In this example, FP8 means the E4M3 attention implementation rather than a
@@ -254,8 +261,19 @@ share one dynamic activation quantization instead of quantizing the same input
 three times. With a partial FP8 layer range, FP8 Dense sends unquantized layers
 to SDPA and FP8 Sol sends unquantized sparse layers to Triton, avoiding a second
 CuTe specialization in the cold-start path.
+In Ulysses mode, BF16 Q/K/V are exchanged first. Each rank then owns the full
+sequence and its local head shard, so fused FP8 preparation computes Q/K block
+scales and V channel scales over the same complete sequence consumed by the
+local Sol kernel. The BF16 attention output is exchanged back before the output
+projection. FP8 operands and scale metadata never need a separate collective.
 The final log reports generation time, frames per second, and peak allocated and
 reserved CUDA memory.
+
+The validated H100 tuning point is `--tau 1.0 --threshold-type diag
+--kv-splits auto`. Higher `tau` is faster but more aggressive and requires
+end-to-end quality validation. `exact` adds threshold-preprocessing cost without
+changing the FP8 arithmetic. See `benchmarks/fp8_sol_sequence_parallel/` for
+the reproducible kernel measurements.
 
 ##### H100 benchmark
 

--- a/examples/wan_video/wan21_1_3b_text_to_video_optimized_h100.py
+++ b/examples/wan_video/wan21_1_3b_text_to_video_optimized_h100.py
@@ -127,6 +127,9 @@ def make_attention_config(
 def get_pipeline(
     *,
     model_root: str = PPL_CONFIG["model_root"],
+    parallelism: int = 1,
+    cfg_degree: int | str = "auto",
+    cfg_scale: float = PPL_CONFIG["cfg_scale"],
     attention: str = "dense",
     quantization: str = "none",
     fp8_linear_scope: str = "auto",
@@ -140,13 +143,24 @@ def get_pipeline(
     sample_solver: str = "euler",
 ) -> Wan21VideoPipeline:
     """Load Wan2.1 with independently selectable attention and quantization."""
+    if parallelism < 1:
+        raise ValueError("parallelism must be positive")
+    if cfg_degree == "auto":
+        cfg_degree = 2 if cfg_scale > 1.0 and parallelism % 2 == 0 else 1
+    cfg_degree = int(cfg_degree)
+    if cfg_degree not in (1, 2) or parallelism % cfg_degree:
+        raise ValueError("cfg_degree must be 1 or 2 and divide parallelism")
+    if parallelism > 1 and quantization not in ("none", "tf-kernel-fp8"):
+        raise ValueError("multi-GPU optimized Wan currently supports no quantization or tf-kernel-fp8")
     fp8_linear_scope = resolve_fp8_linear_scope(attention, fp8_linear_scope)
     quant_config = make_quant_config(quantization, fp8_linear_scope=fp8_linear_scope)
     module_manager = ModuleManager(torch_dtype=torch.bfloat16, device="cpu")
     module_manager.load_model(f"{model_root}/Wan2.1_VAE.pth", device="cpu", torch_dtype=torch.bfloat16)
     module_manager.load_model(
         f"{model_root}/diffusion_pytorch_model.safetensors",
-        device="cuda",
+        # Spawned workers cannot inherit CUDA tensors. FP8Linear keeps a CPU
+        # weight source and materializes its per-device FP8 cache lazily.
+        device="cpu" if parallelism > 1 else "cuda",
         torch_dtype=torch.bfloat16,
         quant_config=quant_config,
     )
@@ -166,6 +180,11 @@ def get_pipeline(
     )
     config.dit_config.quant_config = quant_config
     config.dit_config.offload_config.offload_type = WeightOffloadType.NO_CPU_OFFLOAD
+    if parallelism > 1:
+        config.dit_config.parallel_config.device_ids = list(range(parallelism))
+        config.dit_config.parallel_config.cfg_degree = cfg_degree
+        config.dit_config.parallel_config.sp_ulysses_degree = parallelism // cfg_degree
+        config.enable_denoising_parallel = True
     config.sample_solver = sample_solver
     config.enable_metrics = True
     pipeline.init(module_manager, config)
@@ -218,6 +237,8 @@ def run(
 @click.option("--sigma-shift", default=PPL_CONFIG["sigma_shift"], type=float)
 @click.option("--sample-solver", default="euler", type=click.Choice(["euler", "unipc"]))
 @click.option("--model-root", default=PPL_CONFIG["model_root"])
+@click.option("--parallelism", default=1, type=click.IntRange(min=1))
+@click.option("--cfg-degree", default="auto", type=click.Choice(["auto", "1", "2"]))
 @click.option(
     "--attention",
     default="dense",
@@ -249,6 +270,8 @@ def main(
     sigma_shift: float,
     sample_solver: str,
     model_root: str,
+    parallelism: int,
+    cfg_degree: str,
     attention: str,
     quantization: str,
     fp8_linear_scope: str,
@@ -265,6 +288,9 @@ def main(
     configure_attention_backends()
     pipeline = get_pipeline(
         model_root=model_root,
+        parallelism=parallelism,
+        cfg_degree=cfg_degree,
+        cfg_scale=cfg_scale,
         attention=attention,
         quantization=quantization,
         fp8_linear_scope=fp8_linear_scope,

--- a/telefuser/models/wan_video_dit.py
+++ b/telefuser/models/wan_video_dit.py
@@ -183,20 +183,32 @@ class SelfAttention(nn.Module):
     ) -> torch.Tensor:
         """Async Ulysses-style sequence parallel forward."""
         group = get_ulysses_group(device_mesh)
-        v = self.v(x)
+        input_dtype = x.dtype
+        x = self._prepare_sol_projection_input(x, sparse_state)
+        projection_dtype = x.dtype
+        if all(isinstance(projection, FP8Linear) for projection in (self.q, self.k, self.v)):
+            q, k, v = fp8_linear_forward_many((self.q, self.k, self.v), x)
+            q = self.norm_q(q)
+            k = self.norm_k(k)
+        else:
+            v = self.v(x)
+            q = self.norm_q(self.q(x))
+            k = self.norm_k(self.k(x))
         v = rearrange(v, "b s (n d) -> b s n d", n=self.num_heads)
         v_wait = ulysses_scatter_heads(v, group, tag="v", barrier=False, communicator=self.ulysses_communicator)
-        q = self.norm_q(self.q(x))
         q = rope_apply(q, freqs_cos, freqs_sin, self.num_heads)
         q = rearrange(q, "b s (n d) -> b s n d", n=self.num_heads)
         q_wait = ulysses_scatter_heads(q, group, tag="q", barrier=False, communicator=self.ulysses_communicator)
-        k = self.norm_k(self.k(x))
         k = rope_apply(k, freqs_cos, freqs_sin, self.num_heads)
         k = rearrange(k, "b s (n d) -> b s n d", n=self.num_heads)
         k_wait = ulysses_scatter_heads(k, group, tag="k", communicator=self.ulysses_communicator)
         v = v_wait()
         q = q_wait()
         k = k_wait()
+        # Ulysses turns local-sequence/global-head QKV into
+        # global-sequence/local-head QKV. Quantize afterwards so every rank's
+        # block and channel scales cover the complete attention sequence.
+        q, k, v, scales = self._prepare_sol_qkv(q, k, v, sparse_state)
         if sparse_state is not None and sparse_state.config.sparse_impl == "radial":
             seqlen = q.shape[2]
             q = rearrange(q, "b n s d -> (b s) n d", s=seqlen, n=self.num_heads)
@@ -210,12 +222,19 @@ class SelfAttention(nn.Module):
             sparse_state=sparse_state,
             input_layout="BSND",
             output_layout="BSND",
+            q_scale=None if scales is None else scales[0],
+            k_scale=None if scales is None else scales[1],
+            v_scale=None if scales is None else scales[2],
         )
         out_wait = ulysses_gather_heads(x, group, num_heads=self.num_heads)
         out = out_wait()
         out = rearrange(out, "b s n d -> b s (n d)", n=self.num_heads)
-        out = self.o(out)
-        return out
+        if projection_dtype != input_dtype:
+            out = self.o(out)
+            return out.to(input_dtype)
+        if out.dtype != projection_dtype:
+            out = out.to(input_dtype)
+        return self.o(out)
 
     def forward(
         self,
@@ -399,7 +418,13 @@ class DiTBlock(nn.Module):
 
         input_x = modulate(self.norm1(x), shift_msa, scale_msa)
         if sparse_state is not None:
-            attn_output = self.self_attn(input_x, freqs_cos, freqs_sin, sparse_state=sparse_state)
+            attn_output = self.self_attn(
+                input_x,
+                freqs_cos,
+                freqs_sin,
+                sparse_state=sparse_state,
+                device_mesh=device_mesh,
+            )
         else:
             attn_output = self.self_attn(input_x, freqs_cos, freqs_sin, device_mesh=device_mesh)
         x = self.gate(x, gate_msa, attn_output)
@@ -602,15 +627,23 @@ class WanModel(BaseModel):
         freqs_cos: torch.Tensor,
         freqs_sin: torch.Tensor,
         sparse_state: SparseAttentionState | None = None,
+        *,
+        sol_tokens_preordered: bool = False,
     ) -> torch.Tensor:
-        x, t_mod, freqs_cos, freqs_sin = self._apply_sol_token_order(
-            x, t_mod, freqs_cos, freqs_sin, sparse_state, reorder_tokens=True
-        )
+        if not sol_tokens_preordered:
+            x, t_mod, freqs_cos, freqs_sin = self._apply_sol_token_order(
+                x,
+                t_mod,
+                freqs_cos,
+                freqs_sin,
+                sparse_state,
+                reorder_tokens=True,
+            )
         for block_id, block in enumerate(self.blocks):
             if sparse_state is not None:
                 sparse_state.update(layer_idx=block_id)
             x = block(x, context, t_mod, freqs_cos, freqs_sin, sparse_state=sparse_state, device_mesh=self.device_mesh)
-        return self._restore_sol_token_order(x, sparse_state)
+        return self._restore_sol_token_order(x, sparse_state, enabled=not sol_tokens_preordered)
 
     def forward_blocks_pp(
         self,
@@ -1326,15 +1359,46 @@ class WanModel(BaseModel):
         freqs_cos = freqs.real.contiguous()
         freqs_sin = freqs.imag.contiguous()
 
+        sol_tokens_preordered = self.usp_flag and sparse_state is not None and sparse_state.config.sparse_impl == "sol"
+        if sol_tokens_preordered:
+            # Morton ordering must happen while every rank still has the global
+            # sequence. Applying the global permutation after sharding indexes
+            # past each rank's local token range.
+            x, t_mod, freqs_cos, freqs_sin = self._apply_sol_token_order(
+                x,
+                t_mod,
+                freqs_cos,
+                freqs_sin,
+                sparse_state,
+                reorder_tokens=True,
+            )
+            perm = self.sol_morton_perm.to(t.device)
+            if t.shape[1] == perm.numel():
+                t = t.index_select(1, perm)
+
         if self.usp_flag:
             # Shard t_mod and t (if per-token) along seq_len dimension (dim 1)
             # For scalar timestep, t has seq_len=1 which broadcasts with any seq_len
-            sequence_parallel_shard(self.device_mesh, [x, t_mod, t, freqs_cos, freqs_sin], seq_dims=[1, 1, 1, 0, 0])
+            # and must stay replicated instead of being padded and sharded.
+            sharded_t = t if t.shape[1] > 1 else None
+            sequence_parallel_shard(
+                self.device_mesh,
+                [x, t_mod, sharded_t, freqs_cos, freqs_sin],
+                seq_dims=[1, 1, 1, 0, 0],
+            )
 
         # Feature cache handling - step ID is managed internally
         ori_x = x
         if self.feature_cache.should_compute(cond_flag):
-            x = self.forward_blocks(x, context, t_mod, freqs_cos, freqs_sin, sparse_state=sparse_state)
+            x = self.forward_blocks(
+                x,
+                context,
+                t_mod,
+                freqs_cos,
+                freqs_sin,
+                sparse_state=sparse_state,
+                sol_tokens_preordered=sol_tokens_preordered,
+            )
             self.feature_cache.update(x, ori_x, cond_flag)
         else:
             x = self.feature_cache.approximate(x, cond_flag)
@@ -1342,6 +1406,8 @@ class WanModel(BaseModel):
         x = self.head(x, t)
         if self.usp_flag:
             (x,) = sequence_parallel_unshard(self.device_mesh, (x,), seq_dims=(1,), seq_lens=(f * h * w,))
+        if sol_tokens_preordered:
+            x = self._restore_sol_token_order(x, sparse_state)
         x = self.unpatchify(x, (f, h, w))
         return x
 

--- a/telefuser/ops/fp8_gemm.py
+++ b/telefuser/ops/fp8_gemm.py
@@ -99,8 +99,6 @@ class FP8Linear(nn.Module):
             if linear.bias is not None:
                 self._fp16_bias_cpu = linear.bias.detach().to(device="cpu", dtype=torch.bfloat16).contiguous()
 
-        self._tf_kernel = tf_kernel
-
         # Lazy weight cache (per-device). Register these as non-persistent
         # buffers so module.to()/cpu()/cuda() also migrates the FP8 cache.
         self.register_buffer("_fp8_weight", None, persistent=False)  # [K, N] view
@@ -110,6 +108,15 @@ class FP8Linear(nn.Module):
         # Track when weights change (best-effort) in "keep" mode.
         # Users can also call invalidate_weight_cache() explicitly after weight updates.
         self._last_weight_version: Optional[int] = None
+
+    @property
+    def _tf_kernel(self):
+        # Resolve the extension from module state instead of storing a Python
+        # module on every layer. Module objects are not pickleable, while Wan
+        # sequence-parallel workers use the multiprocessing spawn context.
+        if tf_kernel is None:
+            raise ImportError("tf-kernel is required to run FP8 GEMM")
+        return tf_kernel
 
     @classmethod
     def from_linear(cls, linear: nn.Linear, *, options: FP8GemmOptions) -> "FP8Linear":

--- a/telefuser/pipelines/wan_video/single_dit_denoising.py
+++ b/telefuser/pipelines/wan_video/single_dit_denoising.py
@@ -7,7 +7,7 @@ import torch
 from tqdm import tqdm
 
 from telefuser.core.base_stage import BaseStage, with_model_offload
-from telefuser.core.config import ModelRuntimeConfig, WeightOffloadType
+from telefuser.core.config import ModelRuntimeConfig, SparseAttentionConfig, WeightOffloadType
 from telefuser.core.module_manager import ModuleManager
 from telefuser.distributed.device_mesh import create_device_mesh_from_config, get_cfg_rank, get_cfg_world_size
 from telefuser.distributed.fsdp import shard_model
@@ -75,6 +75,35 @@ class SingleDitDenoisingStage(BaseStage):
         if hasattr(self.dit, "pp_flag") and self.dit.pp_flag:
             return self.dit.pp_forward
         return self.dit.forward
+
+    def enable_sparse_attention(
+        self,
+        *,
+        height: int,
+        width: int,
+        num_frames: int,
+        sparse_config: SparseAttentionConfig,
+    ) -> None:
+        """Configure sparse attention on the local DiT instance."""
+        if sparse_config.sparse_impl == "radial":
+            self.dit.enable_radial_attention(
+                height=height,
+                width=width,
+                num_frames=num_frames,
+                dense_layers=sparse_config.dense_layers,
+                dense_timesteps=sparse_config.dense_timesteps,
+                decay_factor=sparse_config.decay_factor,
+                use_sage_attention=sparse_config.use_sage_attention,
+            )
+        elif sparse_config.sparse_impl == "sol":
+            self.dit.enable_sol_attention(
+                height=height,
+                width=width,
+                num_frames=num_frames,
+                sparse_config=sparse_config,
+            )
+        else:
+            raise ValueError(f"Unsupported Wan sparse attention: {sparse_config.sparse_impl}")
 
     def predict_noise_with_cfg(
         self,

--- a/telefuser/pipelines/wan_video/wan21_video.py
+++ b/telefuser/pipelines/wan_video/wan21_video.py
@@ -167,25 +167,14 @@ class Wan21VideoPipeline(BasePipeline):
             sparse_config = attention_config.sparse_config
             if sparse_config is None:
                 raise ValueError("Sparse attention requires sparse configuration")
-            if sparse_config.sparse_impl == "radial":
-                self.denoise_stage.dit.enable_radial_attention(
-                    height=height,
-                    width=width,
-                    num_frames=num_frames,
-                    dense_layers=sparse_config.dense_layers,
-                    dense_timesteps=sparse_config.dense_timesteps,
-                    decay_factor=sparse_config.decay_factor,
-                    use_sage_attention=sparse_config.use_sage_attention,
-                )
-            elif sparse_config.sparse_impl == "sol":
-                self.denoise_stage.dit.enable_sol_attention(
-                    height=height,
-                    width=width,
-                    num_frames=num_frames,
-                    sparse_config=sparse_config,
-                )
-            else:
-                raise ValueError(f"Unsupported Wan sparse attention: {sparse_config.sparse_impl}")
+            enable_sparse_attention_handler = auto_async_call(
+                self.denoise_stage.enable_sparse_attention,
+                height=height,
+                width=width,
+                num_frames=num_frames,
+                sparse_config=sparse_config,
+            )
+            enable_sparse_attention_handler()
             logger.info(
                 f"Sparse attention enabled ({sparse_config.sparse_impl}): "
                 f"dense_layers={sparse_config.dense_layers}, "

--- a/tests/integration/test_minimax_h3_distributed.py
+++ b/tests/integration/test_minimax_h3_distributed.py
@@ -6,7 +6,15 @@ import pytest
 import torch
 
 from telefuser.core.base_stage import BaseStage
-from telefuser.core.config import AttentionConfig, AttnImplType, ModelRuntimeConfig, ParallelConfig
+from telefuser.core.config import (
+    AttentionConfig,
+    AttnImplType,
+    ModelRuntimeConfig,
+    ParallelConfig,
+    QuantConfig,
+    QuantKernelBackend,
+    QuantType,
+)
 from telefuser.distributed.device_mesh import create_device_mesh_from_config
 from telefuser.models.minimax_h3_dit import MiniMaxH3DiT, MiniMaxH3DiTConfig
 from telefuser.worker import ParallelWorker
@@ -169,6 +177,55 @@ class _MiniMaxH3SageTPUlyssesParityStage(BaseStage):
         return dense, parallel
 
 
+class _MiniMaxH3FP8SolTPUlyssesParityStage(BaseStage):
+    def __init__(self) -> None:
+        super().__init__(
+            "minimax-h3-fp8-sol-tp-ulysses-parity",
+            ModelRuntimeConfig(
+                device_type="cuda",
+                torch_dtype=torch.bfloat16,
+                parallel_config=ParallelConfig(device_ids=[0, 1, 2, 3], sp_ulysses_degree=2, tp_degree=2),
+            ),
+        )
+        torch.manual_seed(41)
+        source = MiniMaxH3DiT(_sage_config()).eval()
+        self.dense = deepcopy(source)
+        self.parallel = deepcopy(source)
+        self.empty_cache_after_call = False
+
+    def parallel_models(self) -> None:
+        mesh = create_device_mesh_from_config(self.model_runtime_config.parallel_config)
+        self.parallel.enable_tp(mesh)
+        self.parallel = self.parallel.to(self.device)
+        self.parallel.enable_usp(mesh)
+        self.parallel.set_attention_config(
+            AttentionConfig.sol_attention(
+                dense_timesteps=0,
+                dense_layers=0,
+                tau=-1000.0,
+                threshold_type="exact",
+                sol_fp8=True,
+            )
+        )
+        self.parallel.enable_quant(
+            QuantConfig(
+                enabled=True,
+                quant_type=QuantType.FP8,
+                kernel_backend=QuantKernelBackend.TF_KERNEL,
+            )
+        )
+        if torch.distributed.get_rank() == 0:
+            self.dense = self.dense.to(self.device)
+            self.dense.set_attention_config(AttentionConfig.dense_attention(AttnImplType.TORCH_SDPA))
+
+    def compare(self, inputs: dict[str, object]) -> tuple[tuple[torch.Tensor, ...], tuple[torch.Tensor, ...]]:
+        parallel = tuple(tensor.cpu() for tensor in self.parallel(**inputs))
+        dense: tuple[torch.Tensor, ...] = ()
+        if torch.distributed.get_rank() == 0:
+            dense = tuple(tensor.cpu() for tensor in self.dense(**inputs))
+        return dense, parallel
+
+
 @pytest.mark.distributed
 @pytest.mark.gpu
 @pytest.mark.multi_gpu
@@ -205,3 +262,22 @@ def test_minimax_h3_sage_sm90_tp2_ulysses2_matches_dense_packed_forward() -> Non
         torch.testing.assert_close(actual, expected, rtol=0.12, atol=0.12)
         cosine = torch.nn.functional.cosine_similarity(actual.flatten(), expected.flatten(), dim=0)
         assert cosine > 0.999
+
+
+@pytest.mark.distributed
+@pytest.mark.gpu
+@pytest.mark.multi_gpu
+def test_minimax_h3_fp8_sol_tp2_ulysses2_matches_dense_packed_forward() -> None:
+    if torch.cuda.device_count() < 4:
+        pytest.skip("requires four CUDA devices")
+    torch.manual_seed(43)
+    worker = ParallelWorker(_MiniMaxH3FP8SolTPUlyssesParityStage())
+    try:
+        dense, parallel = worker.compare(_sage_inputs(), sync=True)
+    finally:
+        worker.close()
+    assert len(dense) == len(parallel) == 2
+    for actual, expected in zip(parallel, dense, strict=True):
+        assert torch.isfinite(actual).all()
+        cosine = torch.nn.functional.cosine_similarity(actual.flatten(), expected.flatten(), dim=0)
+        assert cosine > 0.98

--- a/tests/integration/test_wan_fp8_sol_distributed.py
+++ b/tests/integration/test_wan_fp8_sol_distributed.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from telefuser.core.base_stage import BaseStage
+from telefuser.core.config import AttentionConfig, AttnImplType, ModelRuntimeConfig, ParallelConfig
+from telefuser.distributed.device_mesh import create_device_mesh_from_config
+from telefuser.models.wan_video_dit import SelfAttention
+from telefuser.ops.attention import SparseAttentionState
+from telefuser.worker import ParallelWorker
+
+
+class _WanFP8SolUlyssesParityStage(BaseStage):
+    def __init__(self, degree: int) -> None:
+        super().__init__(
+            "wan-fp8-sol-ulysses-parity",
+            ModelRuntimeConfig(
+                device_type="cuda",
+                torch_dtype=torch.bfloat16,
+                parallel_config=ParallelConfig(device_ids=list(range(degree)), sp_ulysses_degree=degree),
+            ),
+        )
+        torch.manual_seed(41)
+        source = SelfAttention(dim=512, num_heads=4).eval().to(torch.bfloat16)
+        config = AttentionConfig.sol_attention(
+            dense_timesteps=0,
+            dense_layers=0,
+            tau=-1000.0,
+            sol_fp8=True,
+        )
+        source.attention_config = config
+        self.dense = deepcopy(source)
+        self.parallel = deepcopy(source)
+        self.device_mesh = None
+        self.empty_cache_after_call = False
+
+    def parallel_models(self) -> None:
+        self.parallel = self.parallel.to(self.device)
+        self.parallel.usp_flag = True
+        self.device_mesh = create_device_mesh_from_config(self.model_runtime_config.parallel_config)
+        if dist.get_rank() == 0:
+            self.dense = self.dense.to(self.device)
+
+    @staticmethod
+    def _state(module: SelfAttention) -> SparseAttentionState:
+        sparse_config = module.attention_config.sparse_config
+        assert sparse_config is not None
+        return SparseAttentionState(sparse_config, mask_map=None)
+
+    def compare(self, x: torch.Tensor, freqs: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        rank = dist.get_rank()
+        world_size = dist.get_world_size()
+        local_sequence = x.shape[1] // world_size
+        start = rank * local_sequence
+        stop = start + local_sequence
+        parallel_local = self.parallel(
+            x[:, start:stop],
+            freqs[start:stop],
+            freqs[start:stop],
+            sparse_state=self._state(self.parallel),
+            device_mesh=self.device_mesh,
+        )
+        gathered = [torch.empty_like(parallel_local) for _ in range(world_size)]
+        dist.all_gather(gathered, parallel_local)
+        parallel = torch.cat(gathered, dim=1).cpu()
+
+        dense = torch.empty(0)
+        if rank == 0:
+            dense = self.dense(
+                x,
+                freqs,
+                freqs,
+                sparse_state=self._state(self.dense),
+            ).cpu()
+        return dense, parallel
+
+
+@pytest.mark.distributed
+@pytest.mark.gpu
+@pytest.mark.multi_gpu
+@pytest.mark.parametrize("degree", [2, 4])
+def test_wan_fp8_sol_ulysses_matches_single_gpu(degree: int) -> None:
+    if torch.cuda.device_count() < degree:
+        pytest.skip(f"requires {degree} CUDA devices")
+    torch.manual_seed(43)
+    x = torch.randn(1, 256, 512, dtype=torch.bfloat16)
+    freqs = torch.zeros(256, 64, dtype=torch.bfloat16)
+    worker = ParallelWorker(_WanFP8SolUlyssesParityStage(degree))
+    try:
+        dense, parallel = worker.compare(x, freqs, sync=True)
+    finally:
+        worker.close()
+
+    assert dense.shape == parallel.shape == x.shape
+    assert torch.isfinite(parallel).all()
+    torch.testing.assert_close(parallel, dense, rtol=2e-2, atol=2e-2)

--- a/tests/unit/models/test_wan_video_sol_attention.py
+++ b/tests/unit/models/test_wan_video_sol_attention.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 
 from telefuser.core.config import AttentionConfig, AttnImplType, SparseAttentionConfig
-from telefuser.models.wan_video_dit import SelfAttention, WanModel, precompute_freqs_cis_3d
+from telefuser.models.wan_video_dit import DiTBlock, GateModule, SelfAttention, WanModel, precompute_freqs_cis_3d
 from telefuser.ops.attention import SparseAttentionState, attention_impl
 from telefuser.ops.fp8_attention import (
     dequantize_fp8_per_block,
@@ -80,6 +80,81 @@ def test_wan_sol_token_order_round_trip() -> None:
     torch.testing.assert_close(ordered[2], freqs_cos.index_select(0, perm))
     torch.testing.assert_close(ordered[3], freqs_sin.index_select(0, perm))
     torch.testing.assert_close(model._restore_sol_token_order(ordered[0], state), x)
+
+
+def test_wan_sol_preordered_sequence_parallel_shard_skips_global_permutation() -> None:
+    class IdentityBlock(torch.nn.Module):
+        def forward(self, x, *_args, **_kwargs):
+            return x
+
+    model = WanModel.__new__(WanModel)
+    torch.nn.Module.__init__(model)
+    model.patch_size = (1, 2, 2)
+    model.blocks = torch.nn.ModuleList([IdentityBlock()])
+    model.device_mesh = None
+    config = AttentionConfig.sol_attention()
+    assert config.sparse_config is not None
+    model.enable_sol_attention(height=64, width=64, num_frames=5, sparse_config=config.sparse_config)
+    state = model.create_sparse_state()
+
+    local_tokens = model.sol_morton_perm.numel() // 4
+    x = torch.arange(local_tokens).reshape(1, local_tokens, 1)
+    t_mod = x.clone()
+    freqs_cos = torch.arange(local_tokens).reshape(local_tokens, 1)
+    freqs_sin = -freqs_cos
+
+    output = model.forward_blocks(
+        x,
+        torch.empty(0),
+        t_mod,
+        freqs_cos,
+        freqs_sin,
+        sparse_state=state,
+        sol_tokens_preordered=True,
+    )
+
+    torch.testing.assert_close(output, x)
+
+
+def test_wan_block_passes_device_mesh_to_sparse_self_attention() -> None:
+    captured = {}
+
+    class SelfAttentionRecorder(torch.nn.Module):
+        def forward(self, x, *_args, sparse_state=None, device_mesh=None):
+            captured.update(sparse_state=sparse_state, device_mesh=device_mesh)
+            return torch.zeros_like(x)
+
+    class ZeroCrossAttention(torch.nn.Module):
+        def forward(self, x, _context):
+            return torch.zeros_like(x)
+
+    block = DiTBlock.__new__(DiTBlock)
+    torch.nn.Module.__init__(block)
+    block.modulation = torch.nn.Parameter(torch.zeros(1, 6, 8))
+    block.norm1 = torch.nn.Identity()
+    block.norm2 = torch.nn.Identity()
+    block.norm3 = torch.nn.Identity()
+    block.self_attn = SelfAttentionRecorder()
+    block.cross_attn = ZeroCrossAttention()
+    block.ffn = torch.nn.Identity()
+    block.gate = GateModule()
+    config = SparseAttentionConfig(sparse_impl="sol")
+    state = SparseAttentionState(config, mask_map=None)
+    mesh = object()
+
+    x = torch.randn(1, 4, 8)
+    output = block(
+        x,
+        torch.empty(0),
+        torch.zeros(1, 4, 6, 8),
+        torch.empty(0),
+        torch.empty(0),
+        sparse_state=state,
+        device_mesh=mesh,
+    )
+
+    assert output.shape == x.shape
+    assert captured == {"sparse_state": state, "device_mesh": mesh}
 
 
 def test_wan_self_attention_dispatches_sol_through_public_ops() -> None:
@@ -173,6 +248,43 @@ def test_wan_self_attention_quantizes_qkv_for_fp8_sol() -> None:
     assert captured["q_scale"].shape == (1, 2, 1)
     restored = dequantize_fp8_per_block(captured["q"], captured["q_scale"], torch.bfloat16)
     assert torch.isfinite(restored).all()
+
+
+def test_wan_ulysses_quantizes_global_sequence_for_fp8_sol() -> None:
+    module = SelfAttention(dim=256, num_heads=2).to(torch.bfloat16)
+    config = SparseAttentionConfig(sparse_impl="sol", dense_timesteps=0, sol_fp8=True)
+    module.attention_config = AttentionConfig(attn_impl=AttnImplType.SOL_ATTN, sparse_config=config)
+    state = SparseAttentionState(config, mask_map=None)
+    captured = {}
+
+    def scatter(tensor: torch.Tensor, *_args, **_kwargs):
+        # Model the post-all-to-all layout: full sequence and one local head.
+        gathered = torch.cat((tensor[:, :, :1], tensor[:, :, 1:]), dim=1)
+        return lambda: gathered
+
+    def gather(tensor: torch.Tensor, *_args, **_kwargs):
+        return lambda: torch.cat((tensor[:, :65], tensor[:, 65:]), dim=2)
+
+    def fake_attention(q, k, v, **kwargs):
+        captured.update({"q": q, "k": k, "v": v, **kwargs})
+        return q.to(torch.bfloat16)
+
+    x = torch.randn(1, 65, 256, dtype=torch.bfloat16)
+    freqs = torch.zeros(65, 64, dtype=torch.bfloat16)
+    with (
+        patch("telefuser.models.wan_video_dit.get_ulysses_group", return_value=object()),
+        patch("telefuser.models.wan_video_dit.ulysses_scatter_heads", side_effect=scatter),
+        patch("telefuser.models.wan_video_dit.ulysses_gather_heads", side_effect=gather),
+        patch("telefuser.models.wan_video_dit.attn_func", side_effect=fake_attention),
+    ):
+        output = module.async_usp_forward(x, freqs, freqs, sparse_state=state, device_mesh=object())
+
+    assert output.shape == x.shape
+    assert captured["q"].shape == (1, 130, 1, 128)
+    assert captured["q"].dtype is torch.float8_e4m3fn
+    assert captured["q_scale"].shape == (1, 3, 1)
+    assert captured["k_scale"].shape == (1, 3, 1)
+    assert captured["v_scale"].shape == (1, 3, 1)
 
 
 def test_wan_self_attention_limits_fp8_sol_to_configured_layers() -> None:

--- a/tests/unit/ops/test_fp8_gemm.py
+++ b/tests/unit/ops/test_fp8_gemm.py
@@ -1,5 +1,8 @@
 """Tests for the tf-kernel FP8 GEMM wrapper."""
 
+import pickle
+from types import ModuleType
+
 import pytest
 import torch
 import torch.nn as nn
@@ -29,6 +32,22 @@ def test_fp8_linear_keeps_cpu_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
     torch.testing.assert_close(wrapped(inputs), expected)
+
+
+def test_fp8_linear_is_pickleable_for_spawn_workers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(fp8_gemm, "tf_kernel", ModuleType("tf_kernel_test"))
+    wrapped = fp8_gemm.FP8Linear(
+        nn.Linear(8, 4),
+        options=fp8_gemm.FP8GemmOptions(
+            fp16_weight_storage="keep",
+            materialize_fp8_on_wrap=False,
+        ),
+    )
+
+    restored = pickle.loads(pickle.dumps(wrapped))
+
+    inputs = torch.randn(2, 8)
+    torch.testing.assert_close(restored(inputs), wrapped(inputs))
 
 
 @pytest.mark.gpu

--- a/tests/unit/ops/test_sol_attention.py
+++ b/tests/unit/ops/test_sol_attention.py
@@ -6,7 +6,7 @@ import torch
 
 from telefuser.core.config import AttentionConfig, AttnImplType, SparseAttentionConfig
 from telefuser.ops.attention import attention_impl, backends
-from telefuser.ops.attention.attention_impl import SparseAttentionState
+from telefuser.ops.attention.attention_impl import SparseAttentionState, _resolve_sol_kv_splits
 
 
 def test_sol_attention_config_defaults_and_validation() -> None:
@@ -27,6 +27,26 @@ def test_sol_attention_config_defaults_and_validation() -> None:
         AttentionConfig.sol_attention(threshold_type="unknown")
     with pytest.raises(ValueError, match="KV splits"):
         AttentionConfig.sol_attention(kv_splits=3)
+
+
+@pytest.mark.parametrize(
+    ("dtype", "tokens", "expected"),
+    [
+        (torch.float8_e4m3fn, 16383, 1),
+        (torch.float8_e4m3fn, 16384, 2),
+        (torch.float8_e4m3fn, 65536, 2),
+        (torch.bfloat16, 65536, 4),
+    ],
+)
+def test_sol_attention_auto_kv_splits_on_sm90(dtype: torch.dtype, tokens: int, expected: int) -> None:
+    q = MagicMock(dtype=dtype, shape=(1, tokens, 1, 128), device=torch.device("cuda"))
+
+    with patch("telefuser.ops.attention.attention_impl.torch.cuda.get_device_capability", return_value=(9, 0)):
+        assert _resolve_sol_kv_splits(q, "auto") == expected
+
+
+def test_sol_attention_explicit_kv_splits_override_auto_policy() -> None:
+    assert _resolve_sol_kv_splits(MagicMock(), 4) == 4
 
 
 def test_sol_attention_loads_from_telefuser_kernel() -> None:

--- a/tests/unit/pipelines/minimax_h3/test_examples.py
+++ b/tests/unit/pipelines/minimax_h3/test_examples.py
@@ -191,12 +191,20 @@ def test_quantization_names_resolve_to_runtime_config(
 
 
 def test_quantization_rejects_unsupported_parallel_and_cpu_profiles(tmp_path: Path) -> None:
-    with pytest.raises(ValueError, match="single-GPU"):
+    with pytest.raises(ValueError, match="tf-kernel FP8"):
         load_minimax_h3_pipeline(
             tmp_path,
             partition="FL2VA",
             ulysses_degree=2,
             quantization="torchao-fp8",
+        )
+
+    with pytest.raises(FileNotFoundError, match="partition not found"):
+        load_minimax_h3_pipeline(
+            tmp_path,
+            partition="FL2VA",
+            ulysses_degree=2,
+            quantization="tf-kernel-fp8",
         )
 
     (tmp_path / "FL2VA").mkdir()

--- a/tests/unit/pipelines/wan_video/test_optimized_example.py
+++ b/tests/unit/pipelines/wan_video/test_optimized_example.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 
 from examples.wan_video.wan21_1_3b_text_to_video_optimized_h100 import (
+    get_pipeline,
     make_attention_config,
     make_quant_config,
     resolve_fp8_linear_scope,
@@ -101,6 +102,56 @@ def test_wan_optimized_example_uses_all_linear_layers_for_auto_fp8_scope() -> No
 def test_wan_optimized_example_rejects_unknown_fp8_linear_scope() -> None:
     with pytest.raises(ValueError, match="fp8_linear_scope must be"):
         resolve_fp8_linear_scope("fp8-sol", "attention")
+
+
+def test_wan_optimized_pipeline_configures_fp8_sol_ulysses(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = {}
+
+    class Manager:
+        def __init__(self, **_kwargs):
+            pass
+
+        def load_model(self, path, **kwargs):
+            if path.endswith("diffusion_pytorch_model.safetensors"):
+                captured["dit_load"] = kwargs
+
+    class Pipeline:
+        def __init__(self, **_kwargs):
+            pass
+
+        def init(self, _manager, config):
+            captured["config"] = config
+
+    monkeypatch.setattr(
+        "examples.wan_video.wan21_1_3b_text_to_video_optimized_h100.ModuleManager",
+        Manager,
+    )
+    monkeypatch.setattr(
+        "examples.wan_video.wan21_1_3b_text_to_video_optimized_h100.Wan21VideoPipeline",
+        Pipeline,
+    )
+
+    get_pipeline(
+        model_root="/models/wan",
+        parallelism=4,
+        cfg_degree=1,
+        cfg_scale=5.0,
+        attention="fp8-sol",
+        quantization="tf-kernel-fp8",
+    )
+
+    config = captured["config"]
+    assert captured["dit_load"]["device"] == "cpu"
+    assert config.enable_denoising_parallel
+    assert config.dit_config.parallel_config.device_ids == [0, 1, 2, 3]
+    assert config.dit_config.parallel_config.cfg_degree == 1
+    assert config.dit_config.parallel_config.sp_ulysses_degree == 4
+    assert config.dit_config.attention_config.sparse_config.sol_fp8
+
+
+def test_wan_optimized_pipeline_rejects_non_divisible_parallelism() -> None:
+    with pytest.raises(ValueError, match="divide parallelism"):
+        get_pipeline(parallelism=3, cfg_degree=2)
 
 
 def test_wan_model_enables_tf_kernel_fp8_on_transformer_blocks(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/pipelines/wan_video/test_sparse_attention_dispatch.py
+++ b/tests/unit/pipelines/wan_video/test_sparse_attention_dispatch.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from telefuser.core.config import SparseAttentionConfig
+from telefuser.pipelines.wan_video.single_dit_denoising import SingleDitDenoisingStage
+
+
+def _stage_with_mock_dit() -> SingleDitDenoisingStage:
+    stage = SingleDitDenoisingStage.__new__(SingleDitDenoisingStage)
+    stage.dit = MagicMock()
+    return stage
+
+
+def test_stage_enables_sol_attention_on_local_dit() -> None:
+    stage = _stage_with_mock_dit()
+    sparse_config = SparseAttentionConfig(sparse_impl="sol", sol_fp8=True)
+
+    stage.enable_sparse_attention(height=480, width=832, num_frames=81, sparse_config=sparse_config)
+
+    stage.dit.enable_sol_attention.assert_called_once_with(
+        height=480,
+        width=832,
+        num_frames=81,
+        sparse_config=sparse_config,
+    )
+
+
+def test_stage_translates_radial_attention_config() -> None:
+    stage = _stage_with_mock_dit()
+    sparse_config = SparseAttentionConfig(
+        sparse_impl="radial",
+        dense_layers=3,
+        dense_timesteps=7,
+        decay_factor=0.8,
+        use_sage_attention=True,
+    )
+
+    stage.enable_sparse_attention(height=64, width=96, num_frames=17, sparse_config=sparse_config)
+
+    stage.dit.enable_radial_attention.assert_called_once_with(
+        height=64,
+        width=96,
+        num_frames=17,
+        dense_layers=3,
+        dense_timesteps=7,
+        decay_factor=0.8,
+        use_sage_attention=True,
+    )
+
+
+def test_stage_rejects_unsupported_sparse_attention() -> None:
+    stage = _stage_with_mock_dit()
+    sparse_config = SimpleNamespace(sparse_impl="local")
+
+    with pytest.raises(ValueError, match="Unsupported Wan sparse attention: local"):
+        stage.enable_sparse_attention(height=64, width=96, num_frames=17, sparse_config=sparse_config)

--- a/tools/validation/benchmark_fp8_sol_attention.py
+++ b/tools/validation/benchmark_fp8_sol_attention.py
@@ -1,0 +1,184 @@
+"""Benchmark FP8 Sol-Attn with Ulysses-local head counts on Hopper GPUs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+
+from telefuser.kernel.sol_attn import sol_attn
+from telefuser.ops.fp8_attention import quantize_fp8_qkv
+
+
+@dataclass(frozen=True)
+class Result:
+    tokens: int
+    global_heads: int
+    sp_degree: int
+    local_heads: int
+    tau: float
+    threshold_type: str
+    kv_splits: int
+    quantize_ms: float
+    kernel_ms: float
+    total_ms: float
+    reference_ms: float | None
+    cosine: float | None
+    mean_abs_error: float | None
+
+
+def _csv(value: str, cast: Callable[[str], object]) -> list:
+    return [cast(item.strip()) for item in value.split(",") if item.strip()]
+
+
+def _time_cuda(call: Callable[[], object], warmup: int, repeats: int) -> float:
+    for _ in range(warmup):
+        call()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(repeats):
+        call()
+    end.record()
+    end.synchronize()
+    return start.elapsed_time(end) / repeats
+
+
+def _benchmark_case(
+    *,
+    tokens: int,
+    global_heads: int,
+    sp_degree: int,
+    tau: float,
+    threshold_type: str,
+    kv_splits: int,
+    warmup: int,
+    repeats: int,
+    include_reference: bool,
+) -> Result:
+    if global_heads % sp_degree:
+        raise ValueError(f"global heads ({global_heads}) must divide SP degree ({sp_degree})")
+    local_heads = global_heads // sp_degree
+    q = torch.randn((1, tokens, local_heads, 128), device="cuda", dtype=torch.bfloat16)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    q_fp8, k_fp8, v_fp8, q_scale, k_scale, v_scale = quantize_fp8_qkv(q, k, v)
+
+    def run_kernel():
+        return sol_attn(
+            q_fp8,
+            k_fp8,
+            v_fp8,
+            tau=tau,
+            thresh_type=threshold_type,
+            kv_splits=kv_splits,
+            q_scale=q_scale,
+            k_scale=k_scale,
+            v_scale=v_scale,
+        )
+
+    # Compile before timing. CuTe compilation is cached per shape and split.
+    output = run_kernel()
+    quantize_ms = _time_cuda(lambda: quantize_fp8_qkv(q, k, v), warmup, repeats)
+    kernel_ms = _time_cuda(run_kernel, warmup, repeats)
+
+    def run_total():
+        q8, k8, v8, qs, ks, vs = quantize_fp8_qkv(q, k, v)
+        return sol_attn(
+            q8,
+            k8,
+            v8,
+            tau=tau,
+            thresh_type=threshold_type,
+            kv_splits=kv_splits,
+            q_scale=qs,
+            k_scale=ks,
+            v_scale=vs,
+        )
+
+    total_ms = _time_cuda(run_total, warmup, repeats)
+    reference_ms = cosine = mean_abs_error = None
+    if include_reference:
+
+        def run_reference():
+            return F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2))
+
+        reference = run_reference().transpose(1, 2)
+        reference_ms = _time_cuda(run_reference, warmup, repeats)
+        output = output.float()
+        reference = reference.float()
+        cosine = F.cosine_similarity(output.flatten(), reference.flatten(), dim=0).item()
+        mean_abs_error = (output - reference).abs().mean().item()
+
+    return Result(
+        tokens=tokens,
+        global_heads=global_heads,
+        sp_degree=sp_degree,
+        local_heads=local_heads,
+        tau=tau,
+        threshold_type=threshold_type,
+        kv_splits=kv_splits,
+        quantize_ms=quantize_ms,
+        kernel_ms=kernel_ms,
+        total_ms=total_ms,
+        reference_ms=reference_ms,
+        cosine=cosine,
+        mean_abs_error=mean_abs_error,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tokens", default="8192")
+    parser.add_argument("--global-heads", type=int, default=40)
+    parser.add_argument("--sp-degrees", default="1,2,4")
+    parser.add_argument("--taus", default="1.0")
+    parser.add_argument("--threshold-types", default="diag")
+    parser.add_argument("--kv-splits", default="1,2,4")
+    parser.add_argument("--warmup", type=int, default=2)
+    parser.add_argument("--repeats", type=int, default=5)
+    parser.add_argument("--include-reference", action="store_true")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (9, 0):
+        raise RuntimeError("this benchmark requires an NVIDIA Hopper (SM90) GPU")
+    torch.manual_seed(0)
+    results = [
+        _benchmark_case(
+            tokens=tokens,
+            global_heads=args.global_heads,
+            sp_degree=sp_degree,
+            tau=tau,
+            threshold_type=threshold_type,
+            kv_splits=kv_splits,
+            warmup=args.warmup,
+            repeats=args.repeats,
+            include_reference=args.include_reference,
+        )
+        for tokens in _csv(args.tokens, int)
+        for sp_degree in _csv(args.sp_degrees, int)
+        for tau in _csv(args.taus, float)
+        for threshold_type in _csv(args.threshold_types, str)
+        for kv_splits in _csv(args.kv_splits, int)
+    ]
+    payload = {
+        "device": torch.cuda.get_device_name(),
+        "torch": torch.__version__,
+        "results": [asdict(result) for result in results],
+    }
+    serialized = json.dumps(payload, indent=2)
+    print(serialized)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(serialized + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/validation/benchmark_minimax_h3_fp8_sol_sp.py
+++ b/tools/validation/benchmark_minimax_h3_fp8_sol_sp.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Benchmark matched four-GPU MiniMax H3 baseline and FP8 Sol profiles."""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import subprocess
+import threading
+import time
+from importlib import metadata
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from examples.minimax_h3.common import save_generation
+from examples.minimax_h3.minimax_h3_fl2va_h100 import PPL_CONFIG, get_pipeline, run
+from telefuser.core.config import AttnImplType
+from telefuser.pipelines.minimax_h3.pipeline import MiniMaxH3Generation
+
+
+def _package_version(name: str) -> str | None:
+    try:
+        return metadata.version(name)
+    except metadata.PackageNotFoundError:
+        return None
+
+
+def _device_memory_mib() -> list[int]:
+    output = subprocess.run(
+        [
+            "nvidia-smi",
+            "--query-gpu=index,memory.used",
+            "--format=csv,noheader,nounits",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    values: dict[int, int] = {}
+    for line in output.splitlines():
+        index, used_mib = (int(value.strip()) for value in line.split(","))
+        values[index] = used_mib
+    return [values[index] for index in range(4)]
+
+
+def _sample_device_memory(stop: threading.Event, peaks_mib: list[int]) -> None:
+    while not stop.is_set():
+        current = _device_memory_mib()
+        for index, used_mib in enumerate(current):
+            peaks_mib[index] = max(peaks_mib[index], used_mib)
+        stop.wait(0.1)
+
+
+def _generate(pipeline: object, args: argparse.Namespace) -> MiniMaxH3Generation:
+    return run(
+        pipeline,
+        prompt=args.prompt,
+        seed=args.seed,
+        aspect_ratio=args.aspect_ratio,
+        target_video_length=args.duration,
+        mode="t2va",
+    )
+
+
+def _save_arrays(result: MiniMaxH3Generation, output: Path) -> tuple[Path, Path]:
+    frames_path = output.with_suffix(".frames.npy")
+    audio_path = output.with_suffix(".audio.npy")
+    frames = result.video[0].mul(255).clamp(0, 255).to(dtype=torch.uint8).numpy()
+    np.save(frames_path, frames, allow_pickle=False)
+    np.save(audio_path, result.audio[0].float().numpy(), allow_pickle=False)
+    return frames_path, audio_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-root", default=PPL_CONFIG["model_root"])
+    parser.add_argument("--profile", choices=("baseline", "optimized"), required=True)
+    parser.add_argument("--prompt", default=PPL_CONFIG["prompt"])
+    parser.add_argument("--duration", type=float, default=5.0)
+    parser.add_argument("--steps", type=int, default=50)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--aspect-ratio", default="16:9")
+    parser.add_argument("--sol-dense-steps", type=int, default=10)
+    parser.add_argument("--sol-dense-layers", type=int, default=2)
+    parser.add_argument("--sol-tau", type=float, default=1.0)
+    parser.add_argument("--sol-threshold-type", choices=("exact", "diag"), default="exact")
+    parser.add_argument("--sol-fp8-layer-start", type=int, default=0)
+    parser.add_argument("--sol-fp8-layer-end", type=int)
+    parser.add_argument("--no-warmup", action="store_true")
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--metrics-json", type=Path)
+    args = parser.parse_args()
+
+    optimized = args.profile == "optimized"
+    load_started = time.perf_counter()
+    pipeline = get_pipeline(
+        4,
+        args.model_root,
+        num_inference_steps=args.steps,
+        enable_fsdp=False,
+        online_adaln_cache=True,
+        attn_impl=AttnImplType.SOL_ATTN if optimized else AttnImplType.FLASH_ATTN_4,
+        sol_fp8=optimized,
+        sol_dense_steps=args.sol_dense_steps,
+        sol_dense_layers=args.sol_dense_layers,
+        sol_tau=args.sol_tau,
+        sol_threshold_type=args.sol_threshold_type,
+        sol_fp8_layer_start=args.sol_fp8_layer_start,
+        sol_fp8_layer_end=args.sol_fp8_layer_end,
+        quantization="tf-kernel-fp8" if optimized else None,
+    )
+    load_seconds = time.perf_counter() - load_started
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        warmup_seconds = None
+        if not args.no_warmup:
+            warmup_started = time.perf_counter()
+            warmup = _generate(pipeline, args)
+            warmup_seconds = time.perf_counter() - warmup_started
+            del warmup
+            gc.collect()
+
+        resident_memory_mib = _device_memory_mib()
+        peaks_mib = resident_memory_mib.copy()
+        stop_sampling = threading.Event()
+        sampler = threading.Thread(target=_sample_device_memory, args=(stop_sampling, peaks_mib), daemon=True)
+        sampler.start()
+        try:
+            generation_started = time.perf_counter()
+            result = _generate(pipeline, args)
+            generation_seconds = time.perf_counter() - generation_started
+        finally:
+            stop_sampling.set()
+            sampler.join()
+
+        save_started = time.perf_counter()
+        save_generation(result, args.output)
+        frames_path, audio_path = _save_arrays(result, args.output)
+        save_seconds = time.perf_counter() - save_started
+    finally:
+        pipeline.stop()
+
+    denoising_seconds = float(result.runtime_metrics["denoising_seconds"])
+    report = {
+        "schema_version": 1,
+        "profile": args.profile,
+        "parallelism": {"world_size": 4, "ulysses_degree": 2, "tp_degree": 2},
+        "attention": "SOL_ATTN" if optimized else "FLASH_ATTN_4",
+        "linear_quantization": "tf-kernel-fp8" if optimized else None,
+        "sol": (
+            {
+                "fp8_qkv": True,
+                "dense_steps": args.sol_dense_steps,
+                "dense_layers": args.sol_dense_layers,
+                "tau": args.sol_tau,
+                "threshold_type": args.sol_threshold_type,
+                "fp8_layer_start": args.sol_fp8_layer_start,
+                "fp8_layer_end": args.sol_fp8_layer_end,
+            }
+            if optimized
+            else None
+        ),
+        "model_root": str(Path(args.model_root)),
+        "prompt": args.prompt,
+        "duration_seconds": args.duration,
+        "num_inference_steps": args.steps,
+        "seed": args.seed,
+        "aspect_ratio": args.aspect_ratio,
+        "output": str(args.output),
+        "frames": str(frames_path),
+        "audio": str(audio_path),
+        "packed_sequence_length": result.packed_sequence_length,
+        "video_shape": list(result.video.shape),
+        "audio_shape": list(result.audio.shape),
+        "load_seconds": load_seconds,
+        "warmup_seconds": warmup_seconds,
+        "generation_seconds": generation_seconds,
+        "save_seconds": save_seconds,
+        "denoising_steps_per_second": args.steps / denoising_seconds,
+        "generated_video_seconds_per_second": args.duration / generation_seconds,
+        "resident_memory_mib": resident_memory_mib,
+        "peak_memory_mib": peaks_mib,
+        "peak_memory_total_mib": sum(peaks_mib),
+        "runtime_metrics": result.runtime_metrics,
+        "versions": {
+            "torch": _package_version("torch"),
+            "telefuser": _package_version("telefuser"),
+            "tf-kernel": _package_version("tf-kernel"),
+        },
+    }
+    metrics_path = args.metrics_json or args.output.with_suffix(".metrics.json")
+    metrics_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Follow up on #30 by enabling native FP8 Sol-Attn under pure Ulysses sequence parallelism for MiniMax-H3 and Wan

On the matched 4 x H100 MiniMax-H3 workload, TeleFuser FP8 Sol is **2.64x faster end to end**, **2.62x faster in denoising**, and uses **40.3% less representative peak GPU memory** than the deployed LightX2V stack.

## Changes

- Run FP8 Q/K/V after the Ulysses all-to-all, so Q/K block scales and V channel scales cover the exact sequence consumed by each local Sol kernel.
- Ulysses exchanges BF16 Q/K/V before each rank computes FP8 scales over its full-sequence/local-head shard. Restore after the gathered output. 
- Add unit and 4-GPU NCCL parity coverage for MiniMax-H3 TP2 x SP2 and Wan SP2/SP4.
- Tune Sol-Attn configs

## MiniMax-H3: LightX2V vs TeleFuser

Matched workload: 4 x H100 80GB, TP2 x Ulysses SP2, T2AV 1344x768, 124 frames at 24 fps, 50 configured sampling points (49 denoiser updates), seed 0, one complete warm-up followed by one measured request, feature cache disabled, and MP4 serialization excluded from generation timing.

Prompt:

> Steam rises from the ramen while the family talks in the background.

### Performance overview

<img width="1600" height="1180" alt="minimax_h3_combo_performance_steps" src="https://github.com/user-attachments/assets/8ed59b91-43a5-4a4a-8d63-6c9a7000a969" />

- LightX2V uses BF16 Q/K/V inputs dispatch on H100 SM90 to SageAttention2's INT8-QK/FP8-PV kernel with per-thread Q/K quantization, per-channel V quantization, K smoothing, and `fp32+fp32` PV accumulation. Its model weights and Linear layers remain BF16.

## Generated Output Comparison

All three matched outputs were validated as 1344x768, 124-frame, 24 fps H.264 videos with AAC audio. They generate a coherent family ramen scene, but composition and person placement differ. The saved media is therefore intended for subjective review; performance improvements are not presented as numerical output equivalence.

![MiniMax-H3 three-way frame at 2.5 seconds](https://github.com/user-attachments/assets/05134c80-6929-41ce-97a8-1701ec3a9858)

**TeleFuser BF16 + FlashAttention 4**

https://github.com/user-attachments/assets/ddfaeef9-aa56-4611-b226-3ff7380da771

**TeleFuser W8A8 FP8 + FP8 Sol**

https://github.com/user-attachments/assets/2c042a75-1d93-4037-8a54-b57a19c59c76

**LightX2V BF16 Linear + SageAttention2 INT8-QK/FP8-PV**

https://github.com/user-attachments/assets/ce865ab3-5961-45b7-bdcb-f0bbbf31648b

## TeleFuser FP8 Sol Tuning

Against TeleFuser's matched BF16 baseline, the optimized profile reduces generation time by 33.4%, improves denoising throughput by 53.2%, and reduces total sampled peak memory by 14.4%.

Full-model tuning retained `dense_steps=10`, `dense_layers=2`, `tau=1.0`, and `threshold_type=exact`. A `tau=0.5/diag` candidate was slower end to end and did not improve decoded artifact similarity.

H100 microbenchmarks cover 4,096-65,536 global tokens and Ulysses local head counts. Two KV splits remain optimal at and above 16,384 tokens; four splits regress even at 65,536 tokens because workspace and reduction costs outweigh additional KV parallelism. The benchmark and measurements are included under `benchmarks/fp8_sol_sequence_parallel/`.

## Testing

```bash
ruff check <PR-scoped files>
# All checks passed

python -m pytest -q \
  tests/unit/models/test_wan_video_sol_attention.py \
  tests/unit/ops/test_fp8_gemm.py \
  tests/unit/ops/test_sol_attention.py \
  tests/unit/pipelines/minimax_h3/test_examples.py \
  tests/unit/pipelines/wan_video/test_optimized_example.py \
  tests/unit/pipelines/wan_video/test_sparse_attention_dispatch.py
# 86 passed

python -m pytest -q \
  tests/integration/test_minimax_h3_distributed.py::test_minimax_h3_fp8_sol_tp2_ulysses2_matches_dense_packed_forward \
  tests/integration/test_wan_fp8_sol_distributed.py
# 3 passed on 4 x H100
```

## Architecture Support

- Native FP8 Sol kernel: NVIDIA Hopper SM90.
- Pure Ulysses sequence parallelism: supported.
- Tensor parallel + Ulysses: supported for MiniMax-H3.
- Ring and Ulysses-Ring: dense fallback retained.
