### PR TITLE
perf(minimax-h3): optimize Ulysses attention and DiT kernels

### DIFF
--- a/examples/minimax_h3/README.md
+++ b/examples/minimax_h3/README.md
@@ -310,6 +310,13 @@ The Ulysses degree must divide 56 attention heads. Scripts must run from their g
 processes can spawn safely. H100 examples request packed FlashAttention 4 and fall back to packed PyTorch SDPA when
 FlashAttention 4 is unavailable.
 
+The H100 examples also enable the lossless MiniMax-H3 Ulysses optimizations with
+`--attention-chunks 2 --ulysses-sequence-mode valid_only`. Two balanced head chunks overlap Ulysses communication
+with FlashAttention 4, while `valid_only` skips trailing alignment padding in attention and output communication.
+Use `--attention-chunks 1` to disable the overlap, or `--ulysses-sequence-mode padded` to retain padded output
+communication. The fused Q/K RMSNorm + RoPE pack, zero-tail merge, and fused RMSNorm + AdaLN modulation kernels are
+selected automatically only for supported CUDA BF16 layouts; all other inputs retain their original paths.
+
 ## Online DiT Quantization
 
 MiniMax H3 supports three single-GPU online quantization backends for the DiT transformer Linear layers:

--- a/examples/minimax_h3/common.py
+++ b/examples/minimax_h3/common.py
@@ -173,6 +173,8 @@ def load_minimax_h3_pipeline(
     text_encoder_tp_degree: int | None = None,
     enable_fsdp: bool | None = None,
     attn_impl: AttnImplType | str = AttnImplType.FLASH_ATTN_4,
+    attention_chunks: int = 1,
+    ulysses_sequence_mode: str = "padded",
     sol_fp8: bool = False,
     sol_dense_steps: int = 10,
     sol_dense_layers: int = 2,
@@ -267,9 +269,15 @@ def load_minimax_h3_pipeline(
             sol_fp8=sol_fp8,
             sol_fp8_layer_start=sol_fp8_layer_start,
             sol_fp8_layer_end=sol_fp8_layer_end,
+            attention_chunks=attention_chunks,
+            ulysses_sequence_mode=ulysses_sequence_mode,
         )
         if attn_impl == AttnImplType.SOL_ATTN
-        else AttentionConfig.dense_attention(attn_impl)
+        else AttentionConfig.dense_attention(
+            attn_impl,
+            attention_chunks=attention_chunks,
+            ulysses_sequence_mode=ulysses_sequence_mode,
+        )
     )
     dit_runtime = ModelRuntimeConfig(
         device_type=runtime_device.type,

--- a/examples/minimax_h3/minimax_h3_fl2va_h100.py
+++ b/examples/minimax_h3/minimax_h3_fl2va_h100.py
@@ -35,6 +35,8 @@ PPL_CONFIG: dict[str, Any] = {
     "enable_fsdp": None,
     "online_adaln_cache": True,
     "attn_impl": AttnImplType.FLASH_ATTN_4,
+    "attention_chunks": 2,
+    "ulysses_sequence_mode": "valid_only",
     "sol_fp8": False,
     "feature_cache_model_type": "MiniMax-H3-Base",
     "feature_cache_n_derivatives": 1,
@@ -86,6 +88,8 @@ def get_pipeline(
     enable_fsdp: bool | None = PPL_CONFIG["enable_fsdp"],
     online_adaln_cache: bool = PPL_CONFIG["online_adaln_cache"],
     attn_impl: AttnImplType | str = PPL_CONFIG["attn_impl"],
+    attention_chunks: int = PPL_CONFIG["attention_chunks"],
+    ulysses_sequence_mode: str = PPL_CONFIG["ulysses_sequence_mode"],
     sol_fp8: bool = PPL_CONFIG["sol_fp8"],
     sol_dense_steps: int = 10,
     sol_dense_layers: int = 2,
@@ -112,6 +116,8 @@ def get_pipeline(
         enable_fsdp=enable_fsdp,
         online_adaln_cache=online_adaln_cache,
         attn_impl=attn_impl,
+        attention_chunks=attention_chunks,
+        ulysses_sequence_mode=ulysses_sequence_mode,
         sol_fp8=sol_fp8,
         sol_dense_steps=sol_dense_steps,
         sol_dense_layers=sol_dense_layers,
@@ -290,6 +296,12 @@ def _main(default_quantization: str | None = PPL_CONFIG["quantization"]) -> None
         help="Online DiT Linear quantization backend (single GPU only).",
     )
     parser.add_argument("--gpu-num", "--ulysses-degree", dest="gpu_num", type=int, choices=(1, 2, 4), default=1)
+    parser.add_argument("--attention-chunks", type=int, choices=(1, 2), default=PPL_CONFIG["attention_chunks"])
+    parser.add_argument(
+        "--ulysses-sequence-mode",
+        choices=("padded", "valid_only"),
+        default=PPL_CONFIG["ulysses_sequence_mode"],
+    )
     parser.add_argument(
         "--attn-impl",
         choices=("FLASH_ATTN_4", "SAGE_ATTN_2_8_8_SM90", "SOL_ATTN"),
@@ -346,6 +358,8 @@ def _main(default_quantization: str | None = PPL_CONFIG["quantization"]) -> None
         num_inference_steps=args.steps,
         enable_fsdp=args.enable_fsdp,
         attn_impl=args.attn_impl,
+        attention_chunks=args.attention_chunks,
+        ulysses_sequence_mode=args.ulysses_sequence_mode,
         sol_fp8=args.sol_fp8,
         sol_dense_steps=args.sol_dense_steps,
         sol_dense_layers=args.sol_dense_layers,

--- a/examples/minimax_h3/minimax_h3_ref2va_h100.py
+++ b/examples/minimax_h3/minimax_h3_ref2va_h100.py
@@ -36,6 +36,8 @@ PPL_CONFIG: dict[str, Any] = {
     "device": "cuda:0",
     "enable_fsdp": None,
     "online_adaln_cache": True,
+    "attention_chunks": 2,
+    "ulysses_sequence_mode": "valid_only",
     "quantization": None,
 }
 
@@ -92,6 +94,8 @@ def get_pipeline(
     num_inference_steps: int = PPL_CONFIG["num_inference_steps"],
     enable_fsdp: bool | None = PPL_CONFIG["enable_fsdp"],
     online_adaln_cache: bool = PPL_CONFIG["online_adaln_cache"],
+    attention_chunks: int = PPL_CONFIG["attention_chunks"],
+    ulysses_sequence_mode: str = PPL_CONFIG["ulysses_sequence_mode"],
     quantization: str | None = PPL_CONFIG["quantization"],
 ) -> MiniMaxH3Pipeline:
     """Load the Ref2VA checkpoint partition for one, two, or four GPUs."""
@@ -106,6 +110,8 @@ def get_pipeline(
         text_encoder_tp_degree=parallelism,
         enable_fsdp=enable_fsdp,
         online_adaln_cache=online_adaln_cache,
+        attention_chunks=attention_chunks,
+        ulysses_sequence_mode=ulysses_sequence_mode,
         quantization=quantization,
     )
 
@@ -265,6 +271,12 @@ def main() -> None:
     parser.add_argument("--device", default=PPL_CONFIG["device"])
     parser.add_argument("--quantization", choices=("fp8", "torchao-fp8", "tf-kernel-fp8", "bnb-nf4"))
     parser.add_argument("--gpu-num", "--ulysses-degree", dest="gpu_num", type=int, choices=(1, 2, 4), default=1)
+    parser.add_argument("--attention-chunks", type=int, choices=(1, 2), default=PPL_CONFIG["attention_chunks"])
+    parser.add_argument(
+        "--ulysses-sequence-mode",
+        choices=("padded", "valid_only"),
+        default=PPL_CONFIG["ulysses_sequence_mode"],
+    )
     fsdp_group = parser.add_mutually_exclusive_group()
     fsdp_group.add_argument("--enable-fsdp", dest="enable_fsdp", action="store_true")
     fsdp_group.add_argument("--disable-fsdp", dest="enable_fsdp", action="store_false")
@@ -303,6 +315,8 @@ def main() -> None:
         num_inference_steps=request_steps,
         enable_fsdp=args.enable_fsdp,
         online_adaln_cache=online_adaln_cache,
+        attention_chunks=args.attention_chunks,
+        ulysses_sequence_mode=args.ulysses_sequence_mode,
         quantization=args.quantization,
     )
     try:

--- a/examples/minimax_h3/minimax_h3_turbo_lora_h100.py
+++ b/examples/minimax_h3/minimax_h3_turbo_lora_h100.py
@@ -35,6 +35,8 @@ PPL_CONFIG: dict[str, Any] = {
     "device": "cuda:0",
     "enable_fsdp": False,
     "attn_impl": AttnImplType.FLASH_ATTN_4,
+    "attention_chunks": 2,
+    "ulysses_sequence_mode": "valid_only",
 }
 
 PIPELINE_MANIFEST = build_pipeline_manifest(
@@ -64,6 +66,8 @@ def get_pipeline(
     num_inference_steps: int = PPL_CONFIG["num_inference_steps"],
     enable_fsdp: bool | None = PPL_CONFIG["enable_fsdp"],
     attn_impl: AttnImplType | str = PPL_CONFIG["attn_impl"],
+    attention_chunks: int = PPL_CONFIG["attention_chunks"],
+    ulysses_sequence_mode: str = PPL_CONFIG["ulysses_sequence_mode"],
 ) -> MiniMaxH3Pipeline:
     """Load FL2VA and merge Turbo LoRA with the requested GPU parallelism."""
     if parallelism not in {1, 2, 4}:
@@ -79,6 +83,8 @@ def get_pipeline(
         text_encoder_tp_degree=parallelism,
         enable_fsdp=enable_fsdp,
         attn_impl=attn_impl,
+        attention_chunks=attention_chunks,
+        ulysses_sequence_mode=ulysses_sequence_mode,
         lora_path=lora_path,
         lora_strength=lora_strength,
     )
@@ -135,6 +141,12 @@ def run_with_file(
 def main() -> None:
     parser = argparse.ArgumentParser(description="Generate MiniMax H3 Turbo LoRA FL2VA on H100 GPUs")
     parser.add_argument("--gpu-num", "--ulysses-degree", dest="gpu_num", type=int, choices=(1, 2, 4), default=1)
+    parser.add_argument("--attention-chunks", type=int, choices=(1, 2), default=PPL_CONFIG["attention_chunks"])
+    parser.add_argument(
+        "--ulysses-sequence-mode",
+        choices=("padded", "valid_only"),
+        default=PPL_CONFIG["ulysses_sequence_mode"],
+    )
     parser.add_argument("--model-root", default=PPL_CONFIG["model_root"])
     parser.add_argument("--lora-path", default=PPL_CONFIG["lora_path"])
     parser.add_argument("--image", dest="input_image_path", default=PPL_CONFIG["input_image_path"])
@@ -162,6 +174,8 @@ def main() -> None:
         num_inference_steps=args.steps,
         enable_fsdp=args.enable_fsdp,
         attn_impl=args.attn_impl,
+        attention_chunks=args.attention_chunks,
+        ulysses_sequence_mode=args.ulysses_sequence_mode,
     )
     try:
         run(

--- a/telefuser/core/config.py
+++ b/telefuser/core/config.py
@@ -185,6 +185,14 @@ class AttentionConfig:
     scale: float | None = None  # Optional attention scale factor
     dropout: float = 0.0
     is_causal: bool = False
+    attention_chunks: int = 1  # Ulysses/attention overlap chunks; 1 disables overlap
+    ulysses_sequence_mode: str = "padded"  # "valid_only" skips trailing alignment padding
+
+    def __post_init__(self) -> None:
+        if self.attention_chunks not in {1, 2}:
+            raise ValueError("attention_chunks must be 1 or 2")
+        if self.ulysses_sequence_mode not in {"padded", "valid_only"}:
+            raise ValueError("ulysses_sequence_mode must be 'padded' or 'valid_only'")
 
     @classmethod
     def radial_attention(

--- a/telefuser/distributed/ulysses_comm.py
+++ b/telefuser/distributed/ulysses_comm.py
@@ -33,6 +33,24 @@ def _local_head_count(num_heads: int, world_size: int) -> int:
     return num_heads // world_size
 
 
+def _gather_sequence_partition(
+    global_seq_len: int,
+    world_size: int,
+    rank: int,
+    output_sequence_length: int,
+) -> tuple[int, list[int]]:
+    """Return this rank's valid output length and every rank's valid input length."""
+    if output_sequence_length <= 0:
+        raise ValueError("Ulysses gather output sequence length must be positive")
+    if global_seq_len > output_sequence_length * world_size:
+        raise ValueError("Ulysses valid sequence exceeds the padded output capacity")
+    valid_lengths = [
+        max(0, min(output_sequence_length, global_seq_len - destination * output_sequence_length))
+        for destination in range(world_size)
+    ]
+    return valid_lengths[rank], valid_lengths
+
+
 def _wait_async_tensor(tensor: torch.Tensor) -> torch.Tensor:
     """Resolve an asynchronous functional collective tensor."""
     if isinstance(tensor, fc.AsyncCollectiveTensor):
@@ -180,6 +198,107 @@ def ulysses_scatter_qkv(
     def wait() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         result = output.reshape(world_size * local_seq_len, local_heads, 3 * head_dim).unsqueeze(0)
         return result.chunk(3, dim=-1)
+
+    return wait
+
+
+def ulysses_scatter_qkv_qknorm_rope_chunk_async(
+    qkv: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    eps: float,
+    process_group: dist.ProcessGroup,
+    *,
+    local_head_start: int,
+    local_head_count: int,
+) -> Callable[[], tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
+    """Submit one fused Q/K RMSNorm + RoPE + destination-major Ulysses head chunk."""
+    if qkv.ndim != 4 or qkv.shape[1] != 3:
+        raise ValueError("fused Ulysses QKV scatter requires shape [sequence, 3, heads, dim]")
+    _, world_size = _get_distributed_info(process_group)
+    local_seq_len, _, num_heads, head_dim = qkv.shape
+    total_local_heads = _local_head_count(num_heads, world_size)
+    if local_head_start < 0 or local_head_count <= 0 or local_head_start + local_head_count > total_local_heads:
+        raise ValueError("fused Ulysses scatter head chunk falls outside the destination-local heads")
+    if not _can_use_destination_major_kernel(qkv):
+        raise ValueError("fused Ulysses QKV scatter requires eager CUDA FP16/BF16 QKV")
+
+    from telefuser.kernel.triton.ulysses_relayout import pack_qkv_qknorm_rope_destination_major
+
+    packed = pack_qkv_qknorm_rope_destination_major(
+        qkv,
+        q_weight,
+        k_weight,
+        cos_sin_cache,
+        world_size,
+        eps,
+        local_head_start=local_head_start,
+        local_head_count=local_head_count,
+    )
+    output = torch.empty_like(packed.flatten())
+    work = dist.all_to_all_single(output, packed.flatten(), group=process_group, async_op=True)
+
+    def wait() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        work.wait()
+        result = output.reshape(world_size * local_seq_len, local_head_count, 3 * head_dim).unsqueeze(0)
+        return result.chunk(3, dim=-1)
+
+    return wait
+
+
+def ulysses_gather_heads_chunk_async(
+    tensor: torch.Tensor,
+    process_group: dist.ProcessGroup,
+    *,
+    num_heads: int,
+    local_head_start: int,
+    destination: torch.Tensor,
+    zero_tail: bool = False,
+) -> Callable[[], torch.Tensor]:
+    """Submit one valid-only output head chunk and merge it into a padded destination."""
+    if tensor.ndim != 4:
+        raise ValueError("Ulysses head gather requires a 4D tensor")
+    rank, world_size = _get_distributed_info(process_group)
+    batch, global_seq_len, chunk_local_heads, head_dim = tensor.shape
+    total_local_heads = _local_head_count(num_heads, world_size)
+    if local_head_start < 0 or local_head_start + chunk_local_heads > total_local_heads:
+        raise ValueError("Ulysses gather head chunk falls outside the destination-local heads")
+    if not _can_use_destination_major_kernel(tensor):
+        raise ValueError("chunked Ulysses overlap requires CUDA FP16/BF16 attention output")
+    target_seq_len = destination.shape[1]
+    local_seq_len, valid_lengths = _gather_sequence_partition(
+        global_seq_len, world_size, rank, target_seq_len
+    )
+    expected_suffix = (world_size, total_local_heads, head_dim)
+    if destination.shape[0] != batch or tuple(destination.shape[2:]) != expected_suffix:
+        raise ValueError("invalid Ulysses gather destination shape")
+
+    from telefuser.kernel.triton.ulysses_relayout import merge_ulysses_head_chunk
+
+    packed = tensor.permute(1, 0, 2, 3).contiguous()
+    elements_per_token = batch * chunk_local_heads * head_dim
+    input_split_sizes = [length * elements_per_token for length in valid_lengths]
+    output_split_sizes = [local_seq_len * elements_per_token] * world_size
+    output = torch.empty(sum(output_split_sizes), dtype=tensor.dtype, device=tensor.device)
+    work = dist.all_to_all_single(
+        output,
+        packed.flatten(),
+        output_split_sizes=output_split_sizes,
+        input_split_sizes=input_split_sizes,
+        group=process_group,
+        async_op=True,
+    )
+
+    def wait() -> torch.Tensor:
+        work.wait()
+        received = output.reshape(world_size, local_seq_len, batch, chunk_local_heads, head_dim)
+        return merge_ulysses_head_chunk(
+            received,
+            destination,
+            local_head_start=local_head_start,
+            zero_tail=zero_tail,
+        )
 
     return wait
 

--- a/telefuser/distributed/ulysses_comm.py
+++ b/telefuser/distributed/ulysses_comm.py
@@ -267,9 +267,7 @@ def ulysses_gather_heads_chunk_async(
     if not _can_use_destination_major_kernel(tensor):
         raise ValueError("chunked Ulysses overlap requires CUDA FP16/BF16 attention output")
     target_seq_len = destination.shape[1]
-    local_seq_len, valid_lengths = _gather_sequence_partition(
-        global_seq_len, world_size, rank, target_seq_len
-    )
+    local_seq_len, valid_lengths = _gather_sequence_partition(global_seq_len, world_size, rank, target_seq_len)
     expected_suffix = (world_size, total_local_heads, head_dim)
     if destination.shape[0] != batch or tuple(destination.shape[2:]) != expected_suffix:
         raise ValueError("invalid Ulysses gather destination shape")

--- a/telefuser/kernel/triton/indexed_rmsnorm_modulation.py
+++ b/telefuser/kernel/triton/indexed_rmsnorm_modulation.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fused BF16 RMSNorm and indexed AdaLN scale/shift for MiniMax-H3."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _round_bf16_to_fp32(value):
+    bits = value.to(tl.int32, bitcast=True)
+    rounding_bias = 0x7FFF + ((bits >> 16) & 1)
+    rounded_bits = (bits + rounding_bias) & -65536
+    return rounded_bits.to(tl.float32, bitcast=True)
+
+
+@triton.jit
+def _indexed_rmsnorm_scale_shift_bf16_kernel(
+    output_ptr,
+    x_ptr,
+    weight_ptr,
+    shift_ptr,
+    scale_ptr,
+    indices_ptr,
+    hidden_size,
+    parameter_rows,
+    eps,
+    stride_x_row,
+    stride_output_row,
+    stride_shift_row,
+    stride_scale_row,
+    stride_indices,
+    BLOCK_N: tl.constexpr,
+):
+    row = tl.program_id(0)
+    columns = tl.arange(0, BLOCK_N)
+    mask = columns < hidden_size
+    x = tl.load(x_ptr + row * stride_x_row + columns, mask=mask, other=0.0).to(tl.float32)
+    variance = tl.sum(tl.where(mask, x * x, 0.0), axis=0) / hidden_size
+    inv_rms = 1.0 / tl.sqrt(variance + eps)
+    weight = tl.load(weight_ptr + columns, mask=mask, other=1.0).to(tl.float32)
+
+    # Match the standalone RMSNorm BF16 output store/load boundary exactly.
+    normalized = _round_bf16_to_fp32(x * inv_rms * weight)
+    index = tl.load(indices_ptr + row * stride_indices)
+    parameter_mask = mask & (index >= 0) & (index < parameter_rows)
+    shift = tl.load(
+        shift_ptr + index * stride_shift_row + columns,
+        mask=parameter_mask,
+        other=0.0,
+    ).to(tl.float32)
+    scale = tl.load(
+        scale_ptr + index * stride_scale_row + columns,
+        mask=parameter_mask,
+        other=0.0,
+    ).to(tl.float32)
+    one_plus_scale = _round_bf16_to_fp32(1.0 + scale)
+    scaled = _round_bf16_to_fp32(normalized * one_plus_scale)
+    tl.store(output_ptr + row * stride_output_row + columns, scaled + shift, mask=mask)
+
+
+def indexed_rmsnorm_scale_shift_bf16(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    shift: torch.Tensor,
+    scale: torch.Tensor,
+    indices: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    """Return the bit-compatible fusion of RMSNorm and indexed AdaLN modulation."""
+    if x.ndim != 2 or not x.is_contiguous():
+        raise ValueError("fused indexed RMSNorm requires a contiguous 2D input")
+    if x.dtype != torch.bfloat16 or weight.dtype != x.dtype or shift.dtype != x.dtype or scale.dtype != x.dtype:
+        raise TypeError("fused indexed RMSNorm requires matching BF16 tensors")
+    if weight.shape != (x.shape[1],):
+        raise ValueError("RMSNorm weight must match the hidden size")
+    if shift.ndim != 2 or scale.shape != shift.shape or shift.shape[1] != x.shape[1]:
+        raise ValueError("indexed shift/scale must match the input hidden size")
+    if indices.ndim != 1 or indices.numel() != x.shape[0]:
+        raise ValueError("indices must contain one entry per input row")
+    if any(tensor.device != x.device for tensor in (weight, shift, scale, indices)):
+        raise ValueError("all fused indexed RMSNorm tensors must share a device")
+    output = torch.empty_like(x)
+    hidden_size = x.shape[1]
+    block_n = triton.next_power_of_2(hidden_size)
+    _indexed_rmsnorm_scale_shift_bf16_kernel[(x.shape[0],)](
+        output,
+        x,
+        weight,
+        shift,
+        scale,
+        indices,
+        hidden_size,
+        shift.shape[0],
+        eps,
+        x.stride(0),
+        output.stride(0),
+        shift.stride(0),
+        scale.stride(0),
+        indices.stride(0),
+        BLOCK_N=block_n,
+        num_warps=min(max(block_n // 256, 1), 8),
+    )
+    return output

--- a/telefuser/kernel/triton/ulysses_relayout.py
+++ b/telefuser/kernel/triton/ulysses_relayout.py
@@ -197,9 +197,7 @@ def _merge_ulysses_head_chunk_kernel(
     if ZERO_TAIL:
         row = rest % output_sequence
         destination = rest // output_sequence
-        input_vector = (
-            ((destination * sequence + row) * batch + batch_index) * chunk_local_heads + chunk_head
-        )
+        input_vector = ((destination * sequence + row) * batch + batch_index) * chunk_local_heads + chunk_head
         load_mask = mask & (row[:, None] < sequence)
     else:
         row = rest % sequence
@@ -302,10 +300,25 @@ def pack_qkv_qknorm_rope_destination_major(
     total_vectors = rows * world_size * packed_local_heads
     block_n = triton.next_power_of_2(head_dim)
     _pack_qkv_qknorm_rope_destination_major_kernel[(total_vectors,)](
-        output, qkv, q_weight, k_weight, cos_sin_cache, total_vectors, rows,
-        packed_local_heads, total_local_heads, local_head_start, head_dim, rope_dim, eps,
-        qkv.stride(0), qkv.stride(1), qkv.stride(2), cos_sin_cache.stride(0),
-        BLOCK_N=block_n, num_warps=1,
+        output,
+        qkv,
+        q_weight,
+        k_weight,
+        cos_sin_cache,
+        total_vectors,
+        rows,
+        packed_local_heads,
+        total_local_heads,
+        local_head_start,
+        head_dim,
+        rope_dim,
+        eps,
+        qkv.stride(0),
+        qkv.stride(1),
+        qkv.stride(2),
+        cos_sin_cache.stride(0),
+        BLOCK_N=block_n,
+        num_warps=1,
     )
     return output
 
@@ -336,10 +349,21 @@ def merge_ulysses_head_chunk(
     block_head_dim = triton.next_power_of_2(head_dim)
     block_rows = max(1, min(8, 1024 // block_head_dim))
     _merge_ulysses_head_chunk_kernel[(triton.cdiv(total_vectors, block_rows),)](
-        output, tensor, total_vectors, batch, sequence, output.shape[1], total_local_heads,
-        local_head_start, world_size=world_size, chunk_local_heads=chunk_local_heads,
-        head_dim=head_dim, ZERO_TAIL=zero_tail, BLOCK_ROWS=block_rows,
-        BLOCK_HEAD_DIM=block_head_dim, num_warps=8,
+        output,
+        tensor,
+        total_vectors,
+        batch,
+        sequence,
+        output.shape[1],
+        total_local_heads,
+        local_head_start,
+        world_size=world_size,
+        chunk_local_heads=chunk_local_heads,
+        head_dim=head_dim,
+        ZERO_TAIL=zero_tail,
+        BLOCK_ROWS=block_rows,
+        BLOCK_HEAD_DIM=block_head_dim,
+        num_warps=8,
     )
     return output
 

--- a/telefuser/kernel/triton/ulysses_relayout.py
+++ b/telefuser/kernel/triton/ulysses_relayout.py
@@ -17,6 +17,8 @@ def _pack_qkv_destination_major_kernel(
     total_elements,
     rows,
     local_heads,
+    total_local_heads,
+    local_head_start,
     head_dim,
     stride_query_row,
     stride_query_head,
@@ -34,7 +36,7 @@ def _pack_qkv_destination_major_kernel(
     row_slot = head_slot // local_heads
     row = row_slot % rows
     destination = row_slot // rows
-    global_head = destination * local_heads + local_head
+    global_head = destination * total_local_heads + local_head_start + local_head
 
     query = tl.load(
         query_ptr + row * stride_query_row + global_head * stride_query_head + channel,
@@ -52,6 +54,83 @@ def _pack_qkv_destination_major_kernel(
     tl.store(output_ptr + output_base, query, mask=mask)
     tl.store(output_ptr + output_base + head_dim, key, mask=mask)
     tl.store(output_ptr + output_base + 2 * head_dim, value, mask=mask)
+
+
+@triton.jit
+def _round_bf16_to_fp32(value):
+    bits = value.to(tl.int32, bitcast=True)
+    rounding_bias = 0x7FFF + ((bits >> 16) & 1)
+    rounded_bits = (bits + rounding_bias) & -65536
+    return rounded_bits.to(tl.float32, bitcast=True)
+
+
+@triton.jit
+def _pack_qkv_qknorm_rope_destination_major_kernel(
+    output_ptr,
+    qkv_ptr,
+    q_weight_ptr,
+    k_weight_ptr,
+    cache_ptr,
+    total_vectors,
+    rows,
+    packed_local_heads,
+    total_local_heads,
+    local_head_start,
+    head_dim,
+    rope_dim,
+    eps,
+    stride_qkv_row,
+    stride_qkv_section,
+    stride_qkv_head,
+    stride_cache_row,
+    BLOCK_N: tl.constexpr,
+):
+    vector_id = tl.program_id(0)
+    valid_vector = vector_id < total_vectors
+    local_head = vector_id % packed_local_heads
+    row_slot = vector_id // packed_local_heads
+    row = row_slot % rows
+    destination = row_slot // rows
+    global_head = destination * total_local_heads + local_head_start + local_head
+    columns = tl.arange(0, BLOCK_N)
+    mask = valid_vector & (columns < head_dim)
+    q_base = qkv_ptr + row * stride_qkv_row + global_head * stride_qkv_head
+    k_base = q_base + stride_qkv_section
+    v_base = k_base + stride_qkv_section
+
+    query = tl.load(q_base + columns, mask=mask, other=0.0).to(tl.float32)
+    key = tl.load(k_base + columns, mask=mask, other=0.0).to(tl.float32)
+    value = tl.load(v_base + columns, mask=mask, other=0.0)
+    q_weight = tl.load(q_weight_ptr + columns, mask=mask, other=0.0).to(tl.float32)
+    k_weight = tl.load(k_weight_ptr + columns, mask=mask, other=0.0).to(tl.float32)
+    q_inv_rms = tl.rsqrt(tl.sum(query * query, axis=0) / head_dim + eps)
+    k_inv_rms = tl.rsqrt(tl.sum(key * key, axis=0) / head_dim + eps)
+    query = _round_bf16_to_fp32(query * q_inv_rms * q_weight)
+    key = _round_bf16_to_fp32(key * k_inv_rms * k_weight)
+
+    rope_half = rope_dim // 2
+    rotary_mask = mask & (columns < rope_dim)
+    partner_columns = tl.where(columns < rope_half, columns + rope_half, columns - rope_half)
+    q_partner = tl.load(q_base + partner_columns, mask=rotary_mask, other=0.0).to(tl.float32)
+    k_partner = tl.load(k_base + partner_columns, mask=rotary_mask, other=0.0).to(tl.float32)
+    q_partner_weight = tl.load(q_weight_ptr + partner_columns, mask=rotary_mask, other=0.0).to(tl.float32)
+    k_partner_weight = tl.load(k_weight_ptr + partner_columns, mask=rotary_mask, other=0.0).to(tl.float32)
+    q_partner = _round_bf16_to_fp32(q_partner * q_inv_rms * q_partner_weight)
+    k_partner = _round_bf16_to_fp32(k_partner * k_inv_rms * k_partner_weight)
+    frequency_column = columns % rope_half
+    cosine = tl.load(cache_ptr + row * stride_cache_row + frequency_column, mask=rotary_mask, other=1.0).to(tl.float32)
+    sine = tl.load(
+        cache_ptr + row * stride_cache_row + rope_half + frequency_column,
+        mask=rotary_mask,
+        other=0.0,
+    ).to(tl.float32)
+    query = tl.where(columns < rope_half, query * cosine - q_partner * sine, query * cosine + q_partner * sine)
+    key = tl.where(columns < rope_half, key * cosine - k_partner * sine, key * cosine + k_partner * sine)
+
+    output_base = vector_id * (3 * head_dim)
+    tl.store(output_ptr + output_base + columns, query, mask=mask)
+    tl.store(output_ptr + output_base + head_dim + columns, key, mask=mask)
+    tl.store(output_ptr + output_base + 2 * head_dim + columns, value, mask=mask)
 
 
 @triton.jit
@@ -89,15 +168,69 @@ def _merge_ulysses_heads_kernel(
     )
 
 
+@triton.jit
+def _merge_ulysses_head_chunk_kernel(
+    output_ptr,
+    input_ptr,
+    total_vectors,
+    batch,
+    sequence,
+    output_sequence,
+    total_local_heads,
+    local_head_start,
+    world_size: tl.constexpr,
+    chunk_local_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    ZERO_TAIL: tl.constexpr,
+    BLOCK_ROWS: tl.constexpr,
+    BLOCK_HEAD_DIM: tl.constexpr,
+):
+    vector_ids = tl.program_id(0) * BLOCK_ROWS + tl.arange(0, BLOCK_ROWS)
+    channels = tl.arange(0, BLOCK_HEAD_DIM)
+    vector_mask = vector_ids < total_vectors
+    channel_mask = channels < head_dim
+    mask = vector_mask[:, None] & channel_mask[None, :]
+    chunk_head = vector_ids % chunk_local_heads
+    rest = vector_ids // chunk_local_heads
+    batch_index = rest % batch
+    rest //= batch
+    if ZERO_TAIL:
+        row = rest % output_sequence
+        destination = rest // output_sequence
+        input_vector = (
+            ((destination * sequence + row) * batch + batch_index) * chunk_local_heads + chunk_head
+        )
+        load_mask = mask & (row[:, None] < sequence)
+    else:
+        row = rest % sequence
+        destination = rest // sequence
+        input_vector = vector_ids
+        load_mask = mask
+    output_head = destination * total_local_heads + local_head_start + chunk_head
+    values = tl.load(
+        input_ptr + input_vector[:, None] * head_dim + channels[None, :],
+        mask=load_mask,
+        other=0.0,
+    )
+    output_base = (batch_index * output_sequence + row) * (world_size * total_local_heads) + output_head
+    tl.store(output_ptr + output_base[:, None] * head_dim + channels[None, :], values, mask=mask)
+
+
 def pack_qkv_destination_major(
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
     world_size: int,
+    *,
+    local_head_start: int = 0,
+    local_head_count: int | None = None,
 ) -> torch.Tensor:
     """Pack 3D Q/K/V directly as ``[destination, row, local_head, 3 * dim]``."""
     rows, global_heads, head_dim = query.shape
-    local_heads = global_heads // world_size
+    total_local_heads = global_heads // world_size
+    local_heads = total_local_heads - local_head_start if local_head_count is None else local_head_count
+    if local_head_start < 0 or local_heads <= 0 or local_head_start + local_heads > total_local_heads:
+        raise ValueError("Ulysses QKV head chunk falls outside the destination-local heads")
     output = torch.empty(
         world_size,
         rows,
@@ -106,7 +239,7 @@ def pack_qkv_destination_major(
         dtype=query.dtype,
         device=query.device,
     )
-    total_elements = rows * global_heads * head_dim
+    total_elements = rows * world_size * local_heads * head_dim
     if total_elements == 0:
         return output
     block_size = 1024
@@ -118,6 +251,8 @@ def pack_qkv_destination_major(
         total_elements,
         rows,
         local_heads,
+        total_local_heads,
+        local_head_start,
         head_dim,
         query.stride(0),
         query.stride(1),
@@ -127,6 +262,84 @@ def pack_qkv_destination_major(
         value.stride(1),
         BLOCK_SIZE=block_size,
         num_warps=8,
+    )
+    return output
+
+
+def pack_qkv_qknorm_rope_destination_major(
+    qkv: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    world_size: int,
+    eps: float,
+    *,
+    local_head_start: int = 0,
+    local_head_count: int | None = None,
+) -> torch.Tensor:
+    """Normalize/rotate Q/K and pack Q/K/V directly for Ulysses all-to-all."""
+    if qkv.ndim != 4 or qkv.shape[1] != 3:
+        raise ValueError("fused Ulysses QKV pack requires shape [rows, 3, heads, dim]")
+    rows, _, global_heads, head_dim = qkv.shape
+    if world_size <= 0 or global_heads % world_size:
+        raise ValueError("QKV heads must divide the Ulysses world size")
+    if q_weight.shape != (head_dim,) or k_weight.shape != (head_dim,):
+        raise ValueError("Q/K RMSNorm weights must match the QKV head dimension")
+    if cos_sin_cache.ndim != 2 or cos_sin_cache.shape[0] != rows:
+        raise ValueError("RoPE cache must have shape [rows, rotary_dim]")
+    rope_dim = cos_sin_cache.shape[1]
+    if rope_dim <= 0 or rope_dim % 2 or rope_dim > head_dim:
+        raise ValueError("RoPE dimension must be positive, even, and no larger than head_dim")
+    if qkv.dtype != torch.bfloat16 or q_weight.dtype != torch.bfloat16 or k_weight.dtype != torch.bfloat16:
+        raise ValueError("fused Ulysses QKV pack requires BF16 QKV and RMSNorm weights")
+    if not qkv.is_cuda or not q_weight.is_cuda or not k_weight.is_cuda or not cos_sin_cache.is_cuda:
+        raise ValueError("fused Ulysses QKV pack requires CUDA tensors")
+    total_local_heads = global_heads // world_size
+    packed_local_heads = total_local_heads - local_head_start if local_head_count is None else local_head_count
+    if local_head_start < 0 or packed_local_heads <= 0 or local_head_start + packed_local_heads > total_local_heads:
+        raise ValueError("fused Ulysses QKV head chunk falls outside the destination-local heads")
+    output = torch.empty(world_size, rows, packed_local_heads, 3 * head_dim, dtype=qkv.dtype, device=qkv.device)
+    total_vectors = rows * world_size * packed_local_heads
+    block_n = triton.next_power_of_2(head_dim)
+    _pack_qkv_qknorm_rope_destination_major_kernel[(total_vectors,)](
+        output, qkv, q_weight, k_weight, cos_sin_cache, total_vectors, rows,
+        packed_local_heads, total_local_heads, local_head_start, head_dim, rope_dim, eps,
+        qkv.stride(0), qkv.stride(1), qkv.stride(2), cos_sin_cache.stride(0),
+        BLOCK_N=block_n, num_warps=1,
+    )
+    return output
+
+
+def merge_ulysses_head_chunk(
+    tensor: torch.Tensor,
+    output: torch.Tensor,
+    *,
+    local_head_start: int,
+    zero_tail: bool = False,
+) -> torch.Tensor:
+    """Merge one received head chunk into a shared full output tensor."""
+    world_size, sequence, batch, chunk_local_heads, head_dim = tensor.shape
+    if output.ndim != 5 or not output.is_contiguous():
+        raise ValueError("Ulysses chunk destination must be a contiguous 5D tensor")
+    total_local_heads = output.shape[3]
+    if (
+        output.shape[0] != batch
+        or output.shape[1] < sequence
+        or output.shape[2] != world_size
+        or output.shape[-1] != head_dim
+    ):
+        raise ValueError("invalid Ulysses chunk destination shape")
+    if local_head_start < 0 or local_head_start + chunk_local_heads > total_local_heads:
+        raise ValueError("Ulysses gather head chunk falls outside the destination tensor")
+    written_sequence = output.shape[1] if zero_tail else sequence
+    total_vectors = world_size * written_sequence * batch * chunk_local_heads
+    block_head_dim = triton.next_power_of_2(head_dim)
+    block_rows = max(1, min(8, 1024 // block_head_dim))
+    _merge_ulysses_head_chunk_kernel[(triton.cdiv(total_vectors, block_rows),)](
+        output, tensor, total_vectors, batch, sequence, output.shape[1], total_local_heads,
+        local_head_start, world_size=world_size, chunk_local_heads=chunk_local_heads,
+        head_dim=head_dim, ZERO_TAIL=zero_tail, BLOCK_ROWS=block_rows,
+        BLOCK_HEAD_DIM=block_head_dim, num_warps=8,
     )
     return output
 

--- a/telefuser/models/minimax_h3_dit.py
+++ b/telefuser/models/minimax_h3_dit.py
@@ -27,7 +27,12 @@ from telefuser.distributed.device_mesh import (
     get_ulysses_world_size,
 )
 from telefuser.distributed.parallel_shard import sequence_parallel_shard, sequence_parallel_unshard
-from telefuser.distributed.ulysses_comm import ulysses_gather_heads_destination_major, ulysses_scatter_heads
+from telefuser.distributed.ulysses_comm import (
+    ulysses_gather_heads_chunk_async,
+    ulysses_gather_heads_destination_major,
+    ulysses_scatter_heads,
+    ulysses_scatter_qkv_qknorm_rope_chunk_async,
+)
 from telefuser.feature_cache import AdaTaylorCacheCalibrator, NoOpCache
 from telefuser.ops import RMSNorm, apply_qk_norm_rope_neox, indexed_gate, indexed_scale_shift, silu_and_mul_reuse_input
 from telefuser.ops.attention import SparseAttentionState, attention
@@ -53,6 +58,60 @@ MINIMAX_H3_FP32_PARAM_NAMES = frozenset(
     }
 )
 MINIMAX_H3_FP32_BUFFER_NAMES = frozenset({"rope.inv_freq"})
+
+
+def _ulysses_head_chunk_ranges(local_heads: int, chunks: int = 2) -> tuple[tuple[int, int], ...]:
+    """Return balanced, non-empty destination-local head ranges."""
+    if local_heads <= 0 or chunks <= 0 or chunks > local_heads:
+        raise ValueError("invalid Ulysses attention head chunks")
+    base, remainder = divmod(local_heads, chunks)
+    ranges = []
+    start = 0
+    for index in range(chunks):
+        count = base + (1 if index < remainder else 0)
+        ranges.append((start, count))
+        start += count
+    return tuple(ranges)
+
+
+def _can_run_fused_ulysses_attention(
+    qkv: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    attention_config: AttentionConfig | None,
+    sequence_lengths: list[int],
+    rope_cos_sin_cache: torch.Tensor | None,
+    use_ulysses: bool,
+    ulysses_world_size: int,
+) -> bool:
+    """Check whether the lossless fused MiniMax-H3 Ulysses path is supported."""
+    return (
+        use_ulysses
+        and not torch.compiler.is_compiling()
+        and qkv.is_cuda
+        and qkv.dtype == torch.bfloat16
+        and qkv.ndim == 4
+        and qkv.shape[1] == 3
+        and qkv.stride(-1) == 1
+        and q_weight.is_cuda
+        and k_weight.is_cuda
+        and q_weight.dtype == k_weight.dtype == qkv.dtype
+        and q_weight.is_contiguous()
+        and k_weight.is_contiguous()
+        and rope_cos_sin_cache is not None
+        and rope_cos_sin_cache.is_cuda
+        and rope_cos_sin_cache.ndim == 2
+        and rope_cos_sin_cache.shape[0] == qkv.shape[0]
+        and rope_cos_sin_cache.stride(-1) == 1
+        and attention_config is not None
+        and attention_config.attn_impl == AttnImplType.FLASH_ATTN_4
+        and len(sequence_lengths) == 2
+        and sum(sequence_lengths) == qkv.shape[0] * ulysses_world_size
+        and sequence_lengths[0] > 0
+        and 0 < sequence_lengths[1] < 64
+        and sequence_lengths[0] > sequence_lengths[1]
+        and qkv.shape[0] % 64 == 0
+    )
 
 
 @dataclass(frozen=True)
@@ -512,97 +571,165 @@ class MiniMaxH3Attention(nn.Module):
         query, key, value = qkv.unbind(dim=1)
         group = self.ulysses_group
         use_ulysses = group is not None and dist.get_world_size(group) > 1
-        if use_ulysses:
-            value_wait = ulysses_scatter_heads(
-                value.unsqueeze(0), group, tag="v", barrier=False, communicator=self.ulysses_communicator
+        world_size = dist.get_world_size(group) if use_ulysses else 1
+        local_heads = self.num_heads // world_size
+        use_fused_ulysses = _can_run_fused_ulysses_attention(
+            qkv,
+            self.q_norm.weight,
+            self.k_norm.weight,
+            attention_config,
+            sequence_lengths,
+            rope_cos_sin_cache,
+            use_ulysses,
+            world_size,
+        )
+        use_fused_ulysses = (
+            use_fused_ulysses
+            and attention_config is not None
+            and attention_config.attention_chunks <= local_heads
+        )
+        if use_fused_ulysses:
+            chunks = attention_config.attention_chunks
+            head_ranges = _ulysses_head_chunk_ranges(local_heads, chunks=chunks)
+            valid_only = attention_config.ulysses_sequence_mode == "valid_only"
+            destination = torch.empty(
+                1,
+                sequence,
+                world_size,
+                local_heads,
+                self.head_dim,
+                dtype=value.dtype,
+                device=value.device,
             )
-        if rope_cos_sin_cache is not None:
-            query, key = apply_qk_norm_rope_neox(
-                query,
-                key,
-                self.q_norm.weight,
-                self.k_norm.weight,
-                rope_cos_sin_cache,
-                eps=self.q_norm.eps,
-            )
-        else:
-            query = self.q_norm(query)
-            key = self.k_norm(key)
-        query = query.unsqueeze(0)
-        key = key.unsqueeze(0)
-        value = value.unsqueeze(0)
-        if use_ulysses:
-            query_wait = ulysses_scatter_heads(
-                query, group, tag="q", barrier=False, communicator=self.ulysses_communicator
-            )
-            key_wait = ulysses_scatter_heads(key, group, tag="k", communicator=self.ulysses_communicator)
-            query = query_wait()
-            key = key_wait()
-            value = value_wait()
-        optimized_impls = {AttnImplType.SAGE_ATTN_2_8_8_SM90, AttnImplType.SOL_ATTN}
-        if attention_config is not None and attention_config.attn_impl in optimized_impls:
-            total_tokens = query.shape[1]
-            live_tokens = self._live_tokens(sequence_lengths, total_tokens)
-            live_query = query[:, :live_tokens].contiguous()
-            live_key = key[:, :live_tokens].contiguous()
-            live_value = value[:, :live_tokens].contiguous()
-            scales = None
-            runtime_attention_config = attention_config
-            runtime_sparse_state = sparse_state
-            if attention_config.attn_impl == AttnImplType.SOL_ATTN:
-                if sparse_state is None:
-                    raise RuntimeError("MiniMax H3 Sol-Attn requires sparse runtime state")
-                if not 0 <= prefix_tokens <= live_tokens:
-                    raise ValueError("MiniMax H3 Sol-Attn prefix must be within the live packed sequence")
-                sol_query, sol_key, sol_value, scales = self._prepare_sol_qkv(
-                    live_query,
-                    live_key,
-                    live_value,
-                    sparse_state,
+            scatter_waiters = [
+                ulysses_scatter_qkv_qknorm_rope_chunk_async(
+                    qkv,
+                    self.q_norm.weight,
+                    self.k_norm.weight,
+                    rope_cos_sin_cache,
+                    self.q_norm.eps,
+                    group,
+                    local_head_start=start,
+                    local_head_count=count,
                 )
-                if sparse_state.should_use_dense():
-                    runtime_attention_config = AttentionConfig.dense_attention(AttnImplType.FLASH_ATTN_4)
-                    runtime_sparse_state = None
-            else:
-                sol_query, sol_key, sol_value = live_query, live_key, live_value
-            live_output = attention(
-                sol_query,
-                sol_key,
-                sol_value,
-                attention_config=runtime_attention_config,
-                sparse_state=runtime_sparse_state,
-                scale=self.head_dim**-0.5,
-                q_scale=None if scales is None else scales[0],
-                k_scale=None if scales is None else scales[1],
-                v_scale=None if scales is None else scales[2],
-                sink_start=0,
-                sink_tokens=prefix_tokens,
-            )
-            if self._is_sol_active(sparse_state) and prefix_tokens:
-                dense_prefix = F.scaled_dot_product_attention(
-                    live_query[:, :prefix_tokens].transpose(1, 2),
-                    live_key.transpose(1, 2),
-                    live_value.transpose(1, 2),
+                for start, count in head_ranges
+            ]
+            gather_waiters = []
+            for (start, _), scatter_wait in zip(head_ranges, scatter_waiters, strict=True):
+                query_chunk, key_chunk, value_chunk = scatter_wait()
+                output_chunk = attention(
+                    query_chunk,
+                    key_chunk,
+                    value_chunk,
+                    attention_config=attention_config,
                     scale=self.head_dim**-0.5,
-                ).transpose(1, 2)
-                live_output = torch.cat((dense_prefix, live_output[:, prefix_tokens:]), dim=1)
-            if live_tokens == total_tokens:
-                output = live_output
-            else:
-                output = torch.zeros_like(query)
-                output[:, :live_tokens].copy_(live_output)
+                    sequence_lengths=sequence_lengths,
+                    cu_seqlens=cu_seqlens,
+                    fixed_valid=True,
+                    pad_fixed_valid_output=not valid_only,
+                )
+                gather_waiters.append(
+                    ulysses_gather_heads_chunk_async(
+                        output_chunk,
+                        group,
+                        num_heads=self.num_heads,
+                        local_head_start=start,
+                        destination=destination,
+                        zero_tail=valid_only,
+                    )
+                )
+            for gather_wait in gather_waiters:
+                gather_wait()
+            output = destination.flatten(2, 3)
         else:
-            output = attention(
-                query,
-                key,
-                value,
-                attention_config=attention_config,
-                scale=self.head_dim**-0.5,
-                sequence_lengths=sequence_lengths,
-                cu_seqlens=cu_seqlens,
-            )
-        if use_ulysses:
-            output = ulysses_gather_heads_destination_major(output, group, num_heads=self.num_heads)()
+            if use_ulysses:
+                value_wait = ulysses_scatter_heads(
+                    value.unsqueeze(0), group, tag="v", barrier=False, communicator=self.ulysses_communicator
+                )
+            if rope_cos_sin_cache is not None:
+                query, key = apply_qk_norm_rope_neox(
+                    query,
+                    key,
+                    self.q_norm.weight,
+                    self.k_norm.weight,
+                    rope_cos_sin_cache,
+                    eps=self.q_norm.eps,
+                )
+            else:
+                query = self.q_norm(query)
+                key = self.k_norm(key)
+            query = query.unsqueeze(0)
+            key = key.unsqueeze(0)
+            value = value.unsqueeze(0)
+            if use_ulysses:
+                query_wait = ulysses_scatter_heads(
+                    query, group, tag="q", barrier=False, communicator=self.ulysses_communicator
+                )
+                key_wait = ulysses_scatter_heads(key, group, tag="k", communicator=self.ulysses_communicator)
+                query = query_wait()
+                key = key_wait()
+                value = value_wait()
+            optimized_impls = {AttnImplType.SAGE_ATTN_2_8_8_SM90, AttnImplType.SOL_ATTN}
+            if attention_config is not None and attention_config.attn_impl in optimized_impls:
+                total_tokens = query.shape[1]
+                live_tokens = self._live_tokens(sequence_lengths, total_tokens)
+                live_query = query[:, :live_tokens].contiguous()
+                live_key = key[:, :live_tokens].contiguous()
+                live_value = value[:, :live_tokens].contiguous()
+                scales = None
+                runtime_attention_config = attention_config
+                runtime_sparse_state = sparse_state
+                if attention_config.attn_impl == AttnImplType.SOL_ATTN:
+                    if sparse_state is None:
+                        raise RuntimeError("MiniMax H3 Sol-Attn requires sparse runtime state")
+                    if not 0 <= prefix_tokens <= live_tokens:
+                        raise ValueError("MiniMax H3 Sol-Attn prefix must be within the live packed sequence")
+                    sol_query, sol_key, sol_value, scales = self._prepare_sol_qkv(
+                        live_query, live_key, live_value, sparse_state
+                    )
+                    if sparse_state.should_use_dense():
+                        runtime_attention_config = AttentionConfig.dense_attention(AttnImplType.FLASH_ATTN_4)
+                        runtime_sparse_state = None
+                else:
+                    sol_query, sol_key, sol_value = live_query, live_key, live_value
+                live_output = attention(
+                    sol_query,
+                    sol_key,
+                    sol_value,
+                    attention_config=runtime_attention_config,
+                    sparse_state=runtime_sparse_state,
+                    scale=self.head_dim**-0.5,
+                    q_scale=None if scales is None else scales[0],
+                    k_scale=None if scales is None else scales[1],
+                    v_scale=None if scales is None else scales[2],
+                    sink_start=0,
+                    sink_tokens=prefix_tokens,
+                )
+                if self._is_sol_active(sparse_state) and prefix_tokens:
+                    dense_prefix = F.scaled_dot_product_attention(
+                        live_query[:, :prefix_tokens].transpose(1, 2),
+                        live_key.transpose(1, 2),
+                        live_value.transpose(1, 2),
+                        scale=self.head_dim**-0.5,
+                    ).transpose(1, 2)
+                    live_output = torch.cat((dense_prefix, live_output[:, prefix_tokens:]), dim=1)
+                if live_tokens == total_tokens:
+                    output = live_output
+                else:
+                    output = torch.zeros_like(query)
+                    output[:, :live_tokens].copy_(live_output)
+            else:
+                output = attention(
+                    query,
+                    key,
+                    value,
+                    attention_config=attention_config,
+                    scale=self.head_dim**-0.5,
+                    sequence_lengths=sequence_lengths,
+                    cu_seqlens=cu_seqlens,
+                )
+            if use_ulysses:
+                output = ulysses_gather_heads_destination_major(output, group, num_heads=self.num_heads)()
         output = self.out_proj(output[0].reshape(sequence, self.inner_dim))
         if self.tp_group is not None:
             all_reduce_sum_((output,), group=self.tp_group)
@@ -689,6 +816,45 @@ def _modulate(
     return indexed_scale_shift(hidden, shift, scale, indices)
 
 
+def _norm_modulate(
+    norm: RMSNorm,
+    hidden: torch.Tensor,
+    shift: torch.Tensor,
+    scale: torch.Tensor,
+    indices: torch.Tensor,
+) -> torch.Tensor:
+    """Run the bit-compatible RMSNorm + indexed AdaLN fusion when supported."""
+    weight = norm.weight
+    use_fused = (
+        not torch.compiler.is_compiling()
+        and hidden.device.type == "cuda"
+        and hidden.dtype == torch.bfloat16
+        and hidden.ndim == 2
+        and hidden.is_contiguous()
+        and weight is not None
+        and weight.dtype == shift.dtype == scale.dtype == hidden.dtype
+        and weight.is_contiguous()
+        and shift.ndim == scale.ndim == 2
+        and shift.stride(-1) == scale.stride(-1) == 1
+        and indices.ndim == 1
+        and indices.device == hidden.device
+    )
+    if use_fused:
+        from telefuser.kernel.triton.indexed_rmsnorm_modulation import (
+            indexed_rmsnorm_scale_shift_bf16,
+        )
+
+        return indexed_rmsnorm_scale_shift_bf16(
+            hidden,
+            weight,
+            shift,
+            scale,
+            indices.contiguous(),
+            norm.eps,
+        )
+    return _modulate(norm(hidden), shift, scale, indices)
+
+
 class MiniMaxH3TokenRefinerBlock(nn.Module):
     def __init__(self, config: MiniMaxH3DiTConfig) -> None:
         super().__init__()
@@ -767,7 +933,7 @@ class MiniMaxH3DiTBlock(nn.Module):
             adaln_params = self.adaln_proj(adaln_input)
         shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = adaln_params
         residual = hidden
-        value = _modulate(self.norm1(hidden), shift_msa, scale_msa, combined_indices)
+        value = _norm_modulate(self.norm1, hidden, shift_msa, scale_msa, combined_indices)
         value = self.attn(
             value,
             sequence_lengths=sequence_lengths,
@@ -779,7 +945,7 @@ class MiniMaxH3DiTBlock(nn.Module):
         )
         hidden = indexed_gate(residual, gate_msa, value, combined_indices)
         residual = hidden
-        value = _modulate(self.norm2(hidden), shift_mlp, scale_mlp, combined_indices)
+        value = _norm_modulate(self.norm2, hidden, shift_mlp, scale_mlp, combined_indices)
         value = self.mlp(value)
         return indexed_gate(residual, gate_mlp, value, combined_indices)
 
@@ -805,7 +971,7 @@ class MiniMaxH3FinalLayer(nn.Module):
                 raise ValueError("adaln_input is required when no cached AdaLN parameters are supplied.")
             adaln_params = self.adaln_proj(adaln_input)
         shift, scale = adaln_params
-        hidden = _modulate(self.norm(hidden), shift, scale, inverse_indices).float()
+        hidden = _norm_modulate(self.norm, hidden, shift, scale, inverse_indices).float()
         return self.video_out(hidden), self.audio_out(hidden)
 
 

--- a/telefuser/models/minimax_h3_dit.py
+++ b/telefuser/models/minimax_h3_dit.py
@@ -584,9 +584,7 @@ class MiniMaxH3Attention(nn.Module):
             world_size,
         )
         use_fused_ulysses = (
-            use_fused_ulysses
-            and attention_config is not None
-            and attention_config.attention_chunks <= local_heads
+            use_fused_ulysses and attention_config is not None and attention_config.attention_chunks <= local_heads
         )
         if use_fused_ulysses:
             chunks = attention_config.attention_chunks

--- a/telefuser/ops/attention/attention_impl.py
+++ b/telefuser/ops/attention/attention_impl.py
@@ -86,13 +86,33 @@ def _packed_flash_attention4(
     scale: float | None,
     is_causal: bool,
     return_lse: bool,
+    fixed_valid: bool,
+    pad_fixed_valid_output: bool,
     kwargs: dict[str, Any],
 ) -> Tensor | tuple[Tensor, Tensor]:
-    """Run FlashAttention 4 varlen over sequences packed on the BSND axis."""
+    """Run FlashAttention 4 over packed input, optionally skipping trailing padding."""
     if q.shape != k.shape or q.shape != v.shape or q.ndim != 4 or q.shape[0] != 1:
         raise ValueError("packed FlashAttention requires matching Q/K/V tensors with shape [1, sequence, heads, dim]")
     if any(length <= 0 for length in sequence_lengths) or sum(sequence_lengths) != q.shape[1]:
         raise ValueError("packed FlashAttention lengths must be positive and sum to the packed sequence dimension")
+    if fixed_valid:
+        if return_lse:
+            raise ValueError("fixed-valid packed FlashAttention does not support return_lse")
+        valid_length = sequence_lengths[0]
+        result = flash_attn4(
+            q[:, :valid_length],
+            k[:, :valid_length],
+            v[:, :valid_length],
+            softmax_scale=scale,
+            causal=is_causal,
+            return_lse=False,
+            **kwargs,
+        )
+        valid_output = result[0] if isinstance(result, tuple) else result
+        if not pad_fixed_valid_output:
+            return valid_output
+        padding = q.shape[1] - valid_length
+        return F.pad(valid_output, (0, 0, 0, 0, 0, padding)) if padding else valid_output
     if cu_seqlens is None:
         cumulative = [0]
         for length in sequence_lengths:
@@ -195,6 +215,8 @@ def attention(
     v_scale: Tensor | None = None,
     sink_start: int | None = None,
     sink_tokens: int = 0,
+    fixed_valid: bool = False,
+    pad_fixed_valid_output: bool = True,
     **kwargs: Any,
 ) -> Tensor | tuple[Tensor, Tensor]:
     """Unified attention function.
@@ -214,6 +236,8 @@ def attention(
         return_lse: Return log-sum-exp values.
         sequence_lengths: Length of each sequence packed along the sequence axis.
         cu_seqlens: Optional precomputed cumulative sequence lengths for varlen kernels.
+        fixed_valid: Run fixed-shape FA4 only on the first valid packed sequence.
+        pad_fixed_valid_output: Restore trailing padding after fixed-valid FA4.
         sink_start: Start of the exact KV sink used by Sol-Attn.
         sink_tokens: Number of exact KV sink tokens used by Sol-Attn.
         **kwargs: Implementation-specific arguments.
@@ -304,7 +328,7 @@ def attention(
     if attn_impl == AttnImplType.FLASH_ATTN_4 and FLASH_ATTN_4_AVAILABLE and flash_attn4 is not None:
         if sequence_lengths is None:
             result = flash_attn4(q, k, v, softmax_scale=scale, causal=is_causal, return_lse=return_lse, **kwargs)
-        elif flash_attn4_varlen is not None:
+        elif fixed_valid or flash_attn4_varlen is not None:
             if attn_mask is not None or current_layout != "BSND":
                 raise ValueError("packed FlashAttention requires BSND layout without an attention mask")
             result = _packed_flash_attention4(
@@ -316,6 +340,8 @@ def attention(
                 scale=scale,
                 is_causal=is_causal,
                 return_lse=return_lse,
+                fixed_valid=fixed_valid,
+                pad_fixed_valid_output=pad_fixed_valid_output,
                 kwargs=kwargs,
             )
         else:

--- a/tests/unit/kernel/test_minimax_h3_ulysses_kernels.py
+++ b/tests/unit/kernel/test_minimax_h3_ulysses_kernels.py
@@ -1,0 +1,76 @@
+import pytest
+import torch
+
+from telefuser.kernel.triton.ulysses_relayout import (
+    merge_ulysses_head_chunk,
+    pack_qkv_destination_major,
+    pack_qkv_qknorm_rope_destination_major,
+)
+from telefuser.ops.rotary import apply_qk_norm_rope_neox
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA Triton kernels")
+
+
+def test_fused_qknorm_rope_pack_is_bit_exact() -> None:
+    torch.manual_seed(0)
+    rows, heads, head_dim, world_size = 11, 4, 8, 2
+    qkv = torch.randn(rows, 3, heads, head_dim, device="cuda", dtype=torch.bfloat16)
+    q_weight = torch.randn(head_dim, device="cuda", dtype=torch.bfloat16)
+    k_weight = torch.randn(head_dim, device="cuda", dtype=torch.bfloat16)
+    angles = torch.randn(rows, 2, device="cuda")
+    cache = torch.cat((angles.cos(), angles.sin()), dim=-1)
+
+    reference_qkv = qkv.clone()
+    query, key, value = reference_qkv.unbind(dim=1)
+    query, key = apply_qk_norm_rope_neox(
+        query,
+        key,
+        q_weight,
+        k_weight,
+        cache,
+        eps=1e-5,
+    )
+    expected = pack_qkv_destination_major(query, key, value, world_size)
+    actual = pack_qkv_qknorm_rope_destination_major(
+        qkv,
+        q_weight,
+        k_weight,
+        cache,
+        world_size,
+        1e-5,
+    )
+
+    assert torch.equal(actual, expected)
+
+
+def test_merge_head_chunk_writes_valid_data_and_zero_tail() -> None:
+    torch.manual_seed(0)
+    world_size, valid_rows, output_rows = 2, 5, 8
+    batch, chunk_heads, total_local_heads, head_dim = 1, 1, 2, 8
+    received = torch.randn(
+        world_size,
+        valid_rows,
+        batch,
+        chunk_heads,
+        head_dim,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    output = torch.empty(
+        batch,
+        output_rows,
+        world_size,
+        total_local_heads,
+        head_dim,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+
+    actual = merge_ulysses_head_chunk(received, output, local_head_start=1, zero_tail=True)
+
+    expected = torch.empty_like(actual)
+    expected.fill_(float("nan"))
+    expected[:, :, :, 1].zero_()
+    for destination in range(world_size):
+        expected[0, :valid_rows, destination, 1].copy_(received[destination, :, 0, 0])
+    assert torch.equal(actual[:, :, :, 1], expected[:, :, :, 1])

--- a/tests/unit/models/test_minimax_h3_lossless_optimizations.py
+++ b/tests/unit/models/test_minimax_h3_lossless_optimizations.py
@@ -1,0 +1,138 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from telefuser.core.config import AttentionConfig, AttnImplType
+from telefuser.models.minimax_h3_dit import (
+    MiniMaxH3Attention,
+    MiniMaxH3DiTConfig,
+    _modulate,
+    _norm_modulate,
+    _rms_norm,
+)
+
+
+def _small_config() -> MiniMaxH3DiTConfig:
+    return MiniMaxH3DiTConfig(
+        hidden_size=32,
+        num_layers=2,
+        token_refiner_num_layers=1,
+        num_attention_heads=4,
+        attention_head_dim=8,
+        ffn_hidden_size=64,
+        latents_dim=2,
+        audio_latents_dim=2,
+        patch_size=(1, 2, 2),
+        text_dim=16,
+        timestep_input_dim=8,
+        time_embed_hidden_size=32,
+        time_embed_dim=16,
+        rope_inv_freq_len=1,
+    )
+
+
+def test_attention_config_validates_lossless_ulysses_options() -> None:
+    default = AttentionConfig.dense_attention(AttnImplType.FLASH_ATTN_4)
+    assert default.attention_chunks == 1
+    assert default.ulysses_sequence_mode == "padded"
+
+    optimized = AttentionConfig.dense_attention(
+        AttnImplType.FLASH_ATTN_4,
+        attention_chunks=2,
+        ulysses_sequence_mode="valid_only",
+    )
+    assert optimized.attention_chunks == 2
+    assert optimized.ulysses_sequence_mode == "valid_only"
+
+    with pytest.raises(ValueError, match="attention_chunks"):
+        AttentionConfig.dense_attention(AttnImplType.FLASH_ATTN_4, attention_chunks=3)
+    with pytest.raises(ValueError, match="ulysses_sequence_mode"):
+        AttentionConfig.dense_attention(AttnImplType.FLASH_ATTN_4, ulysses_sequence_mode="unknown")
+
+
+@pytest.mark.parametrize(
+    ("chunks", "sequence_mode", "expected_ranges", "pad_output", "zero_tail"),
+    [
+        (1, "padded", [(0, 2)], True, False),
+        (2, "valid_only", [(0, 1), (1, 1)], False, True),
+    ],
+)
+def test_fused_ulysses_path_obeys_public_configuration(
+    chunks: int,
+    sequence_mode: str,
+    expected_ranges: list[tuple[int, int]],
+    pad_output: bool,
+    zero_tail: bool,
+) -> None:
+    module = MiniMaxH3Attention(_small_config()).eval()
+    module.ulysses_group = MagicMock()
+    hidden = torch.randn(8, 32, dtype=torch.bfloat16)
+    rope = torch.randn(8, 2, dtype=torch.bfloat16)
+    scatter_ranges: list[tuple[int, int]] = []
+    attention_options: list[tuple[bool, bool]] = []
+    gather_options: list[bool] = []
+
+    def scatter(*_args: object, local_head_start: int, local_head_count: int, **_kwargs: object):
+        scatter_ranges.append((local_head_start, local_head_count))
+        tensor = torch.zeros(1, 8, local_head_count, 8, dtype=torch.bfloat16)
+        return lambda: (tensor, tensor, tensor)
+
+    def run_attention(query: torch.Tensor, *_args: object, **kwargs: object) -> torch.Tensor:
+        fixed_valid = bool(kwargs["fixed_valid"])
+        pad_fixed_valid_output = bool(kwargs["pad_fixed_valid_output"])
+        attention_options.append((fixed_valid, pad_fixed_valid_output))
+        return query if pad_fixed_valid_output else query[:, :5]
+
+    def gather(*_args: object, destination: torch.Tensor, zero_tail: bool, **_kwargs: object):
+        gather_options.append(zero_tail)
+
+        def wait() -> torch.Tensor:
+            destination.zero_()
+            return destination
+
+        return wait
+
+    config = AttentionConfig.dense_attention(
+        AttnImplType.FLASH_ATTN_4,
+        attention_chunks=chunks,
+        ulysses_sequence_mode=sequence_mode,
+    )
+    with (
+        patch("telefuser.models.minimax_h3_dit.dist.get_world_size", return_value=2),
+        patch("telefuser.models.minimax_h3_dit._can_run_fused_ulysses_attention", return_value=True),
+        patch(
+            "telefuser.models.minimax_h3_dit.ulysses_scatter_qkv_qknorm_rope_chunk_async",
+            side_effect=scatter,
+        ),
+        patch("telefuser.models.minimax_h3_dit.ulysses_gather_heads_chunk_async", side_effect=gather),
+        patch("telefuser.models.minimax_h3_dit.attention", side_effect=run_attention),
+    ):
+        output = module(
+            hidden,
+            sequence_lengths=[5, 3],
+            rope_cos_sin_cache=rope,
+            attention_config=config,
+            cu_seqlens=torch.tensor([0, 5, 8], dtype=torch.int32),
+        )
+
+    assert output.shape == hidden.shape
+    assert scatter_ranges == expected_ranges
+    assert attention_options == [(True, pad_output)] * chunks
+    assert gather_options == [zero_tail] * chunks
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA Triton kernels")
+def test_fused_norm_modulation_is_bit_exact() -> None:
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    norm = _rms_norm(32, 1e-5).to(device=device, dtype=torch.bfloat16)
+    hidden = torch.randn(17, 32, device=device, dtype=torch.bfloat16)
+    shift = torch.randn(3, 32, device=device, dtype=torch.bfloat16)
+    scale = torch.randn(3, 32, device=device, dtype=torch.bfloat16)
+    indices = torch.randint(0, 3, (17,), device=device)
+
+    expected = _modulate(norm(hidden.clone()), shift, scale, indices)
+    actual = _norm_modulate(norm, hidden.clone(), shift, scale, indices)
+
+    assert torch.equal(actual, expected)

--- a/tests/unit/ops/test_attention_backends.py
+++ b/tests/unit/ops/test_attention_backends.py
@@ -97,6 +97,30 @@ def test_flash_attn4_varlen_dispatch_reuses_cumulative_lengths() -> None:
     }
 
 
+@torch.no_grad()
+def test_flash_attn4_fixed_valid_can_return_only_live_tokens() -> None:
+    q = torch.randn(1, 5, 2, 4)
+    flash_attn4 = MagicMock(side_effect=lambda query, *_args, **_kwargs: (query.clone(), None))
+
+    with (
+        patch.object(attention_impl, "FLASH_ATTN_4_AVAILABLE", True),
+        patch.object(attention_impl, "flash_attn4", flash_attn4),
+    ):
+        output = attention_impl.attention(
+            q,
+            q,
+            q,
+            attn_impl=attention_impl.AttnImplType.FLASH_ATTN_4,
+            sequence_lengths=[3, 2],
+            fixed_valid=True,
+            pad_fixed_valid_output=False,
+        )
+
+    assert output.shape == (1, 3, 2, 4)
+    torch.testing.assert_close(output, q[:, :3])
+    assert flash_attn4.call_args.args[0].shape == (1, 3, 2, 4)
+
+
 def test_flash_attn4_packed_falls_back_to_sdpa_without_varlen_backend() -> None:
     q = torch.randn(1, 5, 2, 4)
 

--- a/tests/unit/pipelines/minimax_h3/test_examples.py
+++ b/tests/unit/pipelines/minimax_h3/test_examples.py
@@ -135,6 +135,8 @@ def test_standard_get_pipeline_forwards_parallel_runtime_options(monkeypatch: py
                 "enable_fsdp": True,
                 "online_adaln_cache": True,
                 "attn_impl": AttnImplType.FLASH_ATTN_4,
+                "attention_chunks": 2,
+                "ulysses_sequence_mode": "valid_only",
                 "sol_fp8": False,
                 "sol_dense_steps": 10,
                 "sol_dense_layers": 2,


### PR DESCRIPTION
# TeleFuser MiniMax-H3: Five Lossless Optimizations

## 1. Summary

Under a four-GPU setup with five prompt/seed pairs, the five lossless optimizations reduce the average wall time from 78.546 s to 75.766 s, achieving a 3.539% average speedup. The generated outputs remain bit-exact with the baseline.

| Configuration | Avg. wall time | Speedup vs. baseline | Avg. denoise time | DiT calls |
|---|---:|---:|---:|---:|
| Baseline | 78.546 s | 0.000% | 75.737 s | 49 |
| Five lossless optimizations | 75.766 s | 3.539% | 72.934 s | 49 |

## 2. Optimizations

### 2.1 Overlap Ulysses communication with FlashAttention 4

Added `AttentionConfig.attention_chunks`. The generic default remains 1 to preserve existing behavior; the H100 example uses 2.

MiniMax-H3 attention splits local heads into two chunks. Each chunk enters FA4 immediately after the fused scatter, while its gather is submitted asynchronously, allowing computation for the next chunk to overlap with communication for the previous chunk.

New interfaces include:

- `ulysses_scatter_qkv_qknorm_rope_chunk_async`
- `ulysses_gather_heads_chunk_async`

The new path is enabled only when Ulysses, FA4, CUDA BF16, and the supported tensor layout are all available. Otherwise, execution falls back to the original attention path.

### 2.2 Fuse Q/K RMSNorm, RoPE, and Ulysses Pack

Added the Triton kernel `pack_qkv_qknorm_rope_destination_major`, which performs the following in a single kernel:

1. Q/K RMSNorm;
2. BF16-compatible rounding;
3. RoPE;
4. Q/K/V destination-major Ulysses packing.

This reduces kernel launches, intermediate layout conversions, and temporary tensors. Guards on dtype, device, weights, RoPE cache, head topology, and packed shape ensure that unsupported cases fall back to the original implementation.

### 2.3 Add fixed-valid and valid-only attention modes

FA4 packed attention now supports:

- `fixed_valid`
- `pad_fixed_valid_output`

For MiniMax-H3, valid video tokens are at the front of the packed tensor, while the tail contains alignment padding or auxiliary short sequences. The fixed-valid path runs FA4 only on the valid sequence with a fixed shape. The valid-only mode does not restore the invalid tail after attention, reducing attention and subsequent communication work.

The generic defaults remain:

```text
fixed_valid=False
ulysses_sequence_mode="padded"
```

Therefore, existing call sites retain their original behavior.

### 2.4 Fuse valid-only gather with zero-tail merge

Added the Triton kernel `merge_ulysses_head_chunk`. It writes each received All-to-All head chunk directly into the final destination tensor and clears the invalid tail in the same kernel, avoiding separate relayout, copy, and zero-tail operations.

### 2.5 Fuse RMSNorm with indexed AdaLN modulation

Added the Triton kernel `indexed_rmsnorm_scale_shift_bf16`, which fuses the following sequence in DiT blocks and the final layer:

```text
RMSNorm -> indexed scale/shift modulation
```

The implementation preserves the original BF16 store/load rounding boundaries. CUDA unit tests verify element-wise bit-exact equivalence with the previous path. The fused kernel is enabled only for eager CUDA BF16, contiguous tensors, and valid shapes; other cases fall back to the original `_modulate(norm(hidden), ...)` implementation.

## 3. Per-case performance

| Case | Baseline (s) | Five lossless optimizations (s) | Speedup |
|---|---:|---:|---:|
| P0/S0 | 78.426 | 75.745 | 3.414% |
| P0/S42 | 78.420 | 75.893 | 3.224% |
| P0/S1234 | 78.801 | 75.740 | 3.884% |
| P1/S0 | 78.612 | 75.706 | 3.697% |
| P1/S42 | 78.473 | 75.745 | 3.476% |

## 4. Quality verification

All quality comparisons use the baseline generated with the same prompt and seed, comparing the final video and audio MP4 outputs.

| Configuration | Exact MP4 SHA match | Video PSNR | Video SSIM | Audio cosine | Audio SNR | Audio RMSE |
|---|---:|---:|---:|---:|---:|---:|
| Five lossless optimizations | 5/5 | inf | 1.000000 | 1.000000 | inf | 0 |

Additional hash check:

- `baseline == lossless`: 5/5.

The five optimizations are therefore bit-exact with the baseline at the final video and audio file level, while providing a 3.539% average wall-time speedup.