### PR TITLE
perf(minimax-h3): add conservative DiT velocity reuse

### DIFF
--- a/examples/minimax_h3/README.md
+++ b/examples/minimax_h3/README.md
@@ -310,6 +310,13 @@ The Ulysses degree must divide 56 attention heads. Scripts must run from their g
 processes can spawn safely. H100 examples request packed FlashAttention 4 and fall back to packed PyTorch SDPA when
 FlashAttention 4 is unavailable.
 
+The H100 examples also enable the lossless MiniMax-H3 Ulysses optimizations with
+`--attention-chunks 2 --ulysses-sequence-mode valid_only`. Two balanced head chunks overlap Ulysses communication
+with FlashAttention 4, while `valid_only` skips trailing alignment padding in attention and output communication.
+Use `--attention-chunks 1` to disable the overlap, or `--ulysses-sequence-mode padded` to retain padded output
+communication. The fused Q/K RMSNorm + RoPE pack, zero-tail merge, and fused RMSNorm + AdaLN modulation kernels are
+selected automatically only for supported CUDA BF16 layouts; all other inputs retain their original paths.
+
 ## Online DiT Quantization
 
 MiniMax H3 supports three single-GPU online quantization backends for the DiT transformer Linear layers:

--- a/examples/minimax_h3/README.md
+++ b/examples/minimax_h3/README.md
@@ -317,6 +317,21 @@ Use `--attention-chunks 1` to disable the overlap, or `--ulysses-sequence-mode p
 communication. The fused Q/K RMSNorm + RoPE pack, zero-tail merge, and fused RMSNorm + AdaLN modulation kernels are
 selected automatically only for supported CUDA BF16 layouts; all other inputs retain their original paths.
 
+The FL2VA H100 example also exposes the optional, lossy Conservative DiT cache. It is disabled by default. Enable
+the previously validated schedule with `--dit-cache-mode conservative`: between 20% and 80% of denoising, at most
+one step reuses the preceding DiT video/audio velocity before the next refresh. `velocity` is an equivalent mode
+name, while `probe` records input deltas without skipping DiT calls. The start/end ratios, refresh interval,
+maximum consecutive reuse, and an optional relative-delta threshold have corresponding `--dit-cache-*` flags.
+Conservative DiT cache cannot be combined with Feature Cache or online AdaLN cache collection.
+
+```bash
+python -m examples.minimax_h3.minimax_h3_fl2va_h100 \
+  --gpu-num 4 \
+  --dit-cache-mode conservative \
+  --target-video-length 5 \
+  --output outputs/minimax_h3_conservative.mp4
+```
+
 ## Online DiT Quantization
 
 MiniMax H3 supports three single-GPU online quantization backends for the DiT transformer Linear layers:

--- a/examples/minimax_h3/common.py
+++ b/examples/minimax_h3/common.py
@@ -173,6 +173,8 @@ def load_minimax_h3_pipeline(
     text_encoder_tp_degree: int | None = None,
     enable_fsdp: bool | None = None,
     attn_impl: AttnImplType | str = AttnImplType.FLASH_ATTN_4,
+    attention_chunks: int = 1,
+    ulysses_sequence_mode: str = "padded",
     sol_fp8: bool = False,
     sol_dense_steps: int = 10,
     sol_dense_layers: int = 2,
@@ -267,9 +269,15 @@ def load_minimax_h3_pipeline(
             sol_fp8=sol_fp8,
             sol_fp8_layer_start=sol_fp8_layer_start,
             sol_fp8_layer_end=sol_fp8_layer_end,
+            attention_chunks=attention_chunks,
+            ulysses_sequence_mode=ulysses_sequence_mode,
         )
         if attn_impl == AttnImplType.SOL_ATTN
-        else AttentionConfig.dense_attention(attn_impl)
+        else AttentionConfig.dense_attention(
+            attn_impl,
+            attention_chunks=attention_chunks,
+            ulysses_sequence_mode=ulysses_sequence_mode,
+        )
     )
     dit_runtime = ModelRuntimeConfig(
         device_type=runtime_device.type,

--- a/examples/minimax_h3/common.py
+++ b/examples/minimax_h3/common.py
@@ -30,6 +30,7 @@ from telefuser.models.minimax_h3_audio_vae import MiniMaxH3AudioVAE
 from telefuser.models.minimax_h3_dit import MiniMaxH3DiT
 from telefuser.models.minimax_h3_encoder import MiniMaxH3Encoder
 from telefuser.models.minimax_h3_video_vae import MiniMaxH3VideoVAE
+from telefuser.pipelines.minimax_h3.denoising import MiniMaxH3DiTCacheConfig
 from telefuser.pipelines.minimax_h3.pipeline import (
     MiniMaxH3Generation,
     MiniMaxH3Pipeline,
@@ -183,12 +184,31 @@ def load_minimax_h3_pipeline(
     sol_fp8_layer_start: int = 0,
     sol_fp8_layer_end: int | None = None,
     feature_cache_config: FeatureCacheConfig | None = None,
+    dit_cache_mode: str = "off",
+    dit_cache_start_ratio: float = 0.2,
+    dit_cache_end_ratio: float = 0.8,
+    dit_cache_refresh_interval: int = 2,
+    dit_cache_max_consecutive_reuse: int = 1,
+    dit_cache_threshold: float | None = None,
     adaln_cache_path: str | Path | None = None,
     online_adaln_cache: bool = False,
     quantization: str | QuantType | None = None,
     lora_path: str | Path | None = None,
     lora_strength: float = 1.0,
 ) -> MiniMaxH3Pipeline:
+    dit_cache_config = MiniMaxH3DiTCacheConfig(
+        mode=dit_cache_mode,
+        start_ratio=dit_cache_start_ratio,
+        end_ratio=dit_cache_end_ratio,
+        refresh_interval=dit_cache_refresh_interval,
+        max_consecutive_reuse=dit_cache_max_consecutive_reuse,
+        threshold=dit_cache_threshold,
+    )
+    resolved_feature_cache = feature_cache_config or FeatureCacheConfig()
+    if dit_cache_config.mode != "off" and resolved_feature_cache.enabled:
+        raise ValueError("MiniMax H3 Conservative DiT cache cannot be combined with Feature Cache")
+    if dit_cache_config.mode != "off" and online_adaln_cache:
+        raise ValueError("MiniMax H3 Conservative DiT cache cannot be combined with online AdaLN cache collection")
     if adaln_cache_path is not None and online_adaln_cache:
         raise ValueError("Choose either adaln_cache_path or online_adaln_cache, not both.")
 
@@ -285,7 +305,7 @@ def load_minimax_h3_pipeline(
         torch_dtype=torch.bfloat16,
         offload_config=dit_offload,
         attention_config=attention_config,
-        feature_cache_config=feature_cache_config or FeatureCacheConfig(),
+        feature_cache_config=resolved_feature_cache,
         quant_config=quant_config,
         lora_configs=[LoraConfig(path=str(lora_path), strength=lora_strength)] if lora_path else [],
         parallel_config=ParallelConfig(
@@ -375,6 +395,7 @@ def load_minimax_h3_pipeline(
             video_vae_config=video_vae_runtime,
             audio_vae_config=audio_vae_runtime,
             num_inference_steps=num_inference_steps,
+            dit_cache_config=dit_cache_config,
         ),
     )
     return pipeline

--- a/examples/minimax_h3/minimax_h3_fl2va_h100.py
+++ b/examples/minimax_h3/minimax_h3_fl2va_h100.py
@@ -35,6 +35,8 @@ PPL_CONFIG: dict[str, Any] = {
     "enable_fsdp": None,
     "online_adaln_cache": True,
     "attn_impl": AttnImplType.FLASH_ATTN_4,
+    "attention_chunks": 2,
+    "ulysses_sequence_mode": "valid_only",
     "sol_fp8": False,
     "feature_cache_model_type": "MiniMax-H3-Base",
     "feature_cache_n_derivatives": 1,
@@ -86,6 +88,8 @@ def get_pipeline(
     enable_fsdp: bool | None = PPL_CONFIG["enable_fsdp"],
     online_adaln_cache: bool = PPL_CONFIG["online_adaln_cache"],
     attn_impl: AttnImplType | str = PPL_CONFIG["attn_impl"],
+    attention_chunks: int = PPL_CONFIG["attention_chunks"],
+    ulysses_sequence_mode: str = PPL_CONFIG["ulysses_sequence_mode"],
     sol_fp8: bool = PPL_CONFIG["sol_fp8"],
     sol_dense_steps: int = 10,
     sol_dense_layers: int = 2,
@@ -112,6 +116,8 @@ def get_pipeline(
         enable_fsdp=enable_fsdp,
         online_adaln_cache=online_adaln_cache,
         attn_impl=attn_impl,
+        attention_chunks=attention_chunks,
+        ulysses_sequence_mode=ulysses_sequence_mode,
         sol_fp8=sol_fp8,
         sol_dense_steps=sol_dense_steps,
         sol_dense_layers=sol_dense_layers,
@@ -290,6 +296,12 @@ def _main(default_quantization: str | None = PPL_CONFIG["quantization"]) -> None
         help="Online DiT Linear quantization backend (single GPU only).",
     )
     parser.add_argument("--gpu-num", "--ulysses-degree", dest="gpu_num", type=int, choices=(1, 2, 4), default=1)
+    parser.add_argument("--attention-chunks", type=int, choices=(1, 2), default=PPL_CONFIG["attention_chunks"])
+    parser.add_argument(
+        "--ulysses-sequence-mode",
+        choices=("padded", "valid_only"),
+        default=PPL_CONFIG["ulysses_sequence_mode"],
+    )
     parser.add_argument(
         "--attn-impl",
         choices=("FLASH_ATTN_4", "SAGE_ATTN_2_8_8_SM90", "SOL_ATTN"),
@@ -346,6 +358,8 @@ def _main(default_quantization: str | None = PPL_CONFIG["quantization"]) -> None
         num_inference_steps=args.steps,
         enable_fsdp=args.enable_fsdp,
         attn_impl=args.attn_impl,
+        attention_chunks=args.attention_chunks,
+        ulysses_sequence_mode=args.ulysses_sequence_mode,
         sol_fp8=args.sol_fp8,
         sol_dense_steps=args.sol_dense_steps,
         sol_dense_layers=args.sol_dense_layers,

--- a/examples/minimax_h3/minimax_h3_fl2va_h100.py
+++ b/examples/minimax_h3/minimax_h3_fl2va_h100.py
@@ -86,10 +86,16 @@ def get_pipeline(
     device: str = PPL_CONFIG["device"],
     num_inference_steps: int = PPL_CONFIG["num_inference_steps"],
     enable_fsdp: bool | None = PPL_CONFIG["enable_fsdp"],
-    online_adaln_cache: bool = PPL_CONFIG["online_adaln_cache"],
+    online_adaln_cache: bool | None = None,
     attn_impl: AttnImplType | str = PPL_CONFIG["attn_impl"],
     attention_chunks: int = PPL_CONFIG["attention_chunks"],
     ulysses_sequence_mode: str = PPL_CONFIG["ulysses_sequence_mode"],
+    dit_cache_mode: str = "off",
+    dit_cache_start_ratio: float = 0.2,
+    dit_cache_end_ratio: float = 0.8,
+    dit_cache_refresh_interval: int = 2,
+    dit_cache_max_consecutive_reuse: int = 1,
+    dit_cache_threshold: float | None = None,
     sol_fp8: bool = PPL_CONFIG["sol_fp8"],
     sol_dense_steps: int = 10,
     sol_dense_layers: int = 2,
@@ -105,6 +111,10 @@ def get_pipeline(
 ) -> MiniMaxH3Pipeline:
     """Load the FL2VA checkpoint partition for one, two, or four GPUs."""
     tp_degree = 2 if parallelism == 4 else 1
+    normalized_cache_mode = str(dit_cache_mode).strip().lower().replace("_", "-")
+    resolved_online_adaln_cache = (
+        PPL_CONFIG["online_adaln_cache"] if normalized_cache_mode == "off" else False
+    ) if online_adaln_cache is None else online_adaln_cache
     return load_minimax_h3_pipeline(
         model_root,
         partition=PPL_CONFIG["partition"],
@@ -114,10 +124,16 @@ def get_pipeline(
         tp_degree=tp_degree,
         text_encoder_tp_degree=parallelism,
         enable_fsdp=enable_fsdp,
-        online_adaln_cache=online_adaln_cache,
+        online_adaln_cache=resolved_online_adaln_cache,
         attn_impl=attn_impl,
         attention_chunks=attention_chunks,
         ulysses_sequence_mode=ulysses_sequence_mode,
+        dit_cache_mode=dit_cache_mode,
+        dit_cache_start_ratio=dit_cache_start_ratio,
+        dit_cache_end_ratio=dit_cache_end_ratio,
+        dit_cache_refresh_interval=dit_cache_refresh_interval,
+        dit_cache_max_consecutive_reuse=dit_cache_max_consecutive_reuse,
+        dit_cache_threshold=dit_cache_threshold,
         sol_fp8=sol_fp8,
         sol_dense_steps=sol_dense_steps,
         sol_dense_layers=sol_dense_layers,
@@ -303,6 +319,21 @@ def _main(default_quantization: str | None = PPL_CONFIG["quantization"]) -> None
         default=PPL_CONFIG["ulysses_sequence_mode"],
     )
     parser.add_argument(
+        "--dit-cache-mode",
+        choices=("off", "conservative", "probe", "velocity"),
+        default="off",
+        help="Lossy previous-velocity reuse; 'conservative' is the validated velocity schedule.",
+    )
+    parser.add_argument("--dit-cache-start-ratio", type=float, default=0.2)
+    parser.add_argument("--dit-cache-end-ratio", type=float, default=0.8)
+    parser.add_argument("--dit-cache-refresh-interval", type=int, default=2)
+    parser.add_argument("--dit-cache-max-consecutive-reuse", type=int, default=1)
+    parser.add_argument(
+        "--dit-cache-threshold",
+        type=float,
+        help="Optional maximum relative input delta; omitted keeps the synchronization-free schedule.",
+    )
+    parser.add_argument(
         "--attn-impl",
         choices=("FLASH_ATTN_4", "SAGE_ATTN_2_8_8_SM90", "SOL_ATTN"),
         default=PPL_CONFIG["attn_impl"].name,
@@ -360,6 +391,12 @@ def _main(default_quantization: str | None = PPL_CONFIG["quantization"]) -> None
         attn_impl=args.attn_impl,
         attention_chunks=args.attention_chunks,
         ulysses_sequence_mode=args.ulysses_sequence_mode,
+        dit_cache_mode=args.dit_cache_mode,
+        dit_cache_start_ratio=args.dit_cache_start_ratio,
+        dit_cache_end_ratio=args.dit_cache_end_ratio,
+        dit_cache_refresh_interval=args.dit_cache_refresh_interval,
+        dit_cache_max_consecutive_reuse=args.dit_cache_max_consecutive_reuse,
+        dit_cache_threshold=args.dit_cache_threshold,
         sol_fp8=args.sol_fp8,
         sol_dense_steps=args.sol_dense_steps,
         sol_dense_layers=args.sol_dense_layers,

--- a/examples/minimax_h3/minimax_h3_ref2va_h100.py
+++ b/examples/minimax_h3/minimax_h3_ref2va_h100.py
@@ -36,6 +36,8 @@ PPL_CONFIG: dict[str, Any] = {
     "device": "cuda:0",
     "enable_fsdp": None,
     "online_adaln_cache": True,
+    "attention_chunks": 2,
+    "ulysses_sequence_mode": "valid_only",
     "quantization": None,
 }
 
@@ -92,6 +94,8 @@ def get_pipeline(
     num_inference_steps: int = PPL_CONFIG["num_inference_steps"],
     enable_fsdp: bool | None = PPL_CONFIG["enable_fsdp"],
     online_adaln_cache: bool = PPL_CONFIG["online_adaln_cache"],
+    attention_chunks: int = PPL_CONFIG["attention_chunks"],
+    ulysses_sequence_mode: str = PPL_CONFIG["ulysses_sequence_mode"],
     quantization: str | None = PPL_CONFIG["quantization"],
 ) -> MiniMaxH3Pipeline:
     """Load the Ref2VA checkpoint partition for one, two, or four GPUs."""
@@ -106,6 +110,8 @@ def get_pipeline(
         text_encoder_tp_degree=parallelism,
         enable_fsdp=enable_fsdp,
         online_adaln_cache=online_adaln_cache,
+        attention_chunks=attention_chunks,
+        ulysses_sequence_mode=ulysses_sequence_mode,
         quantization=quantization,
     )
 
@@ -265,6 +271,12 @@ def main() -> None:
     parser.add_argument("--device", default=PPL_CONFIG["device"])
     parser.add_argument("--quantization", choices=("fp8", "torchao-fp8", "tf-kernel-fp8", "bnb-nf4"))
     parser.add_argument("--gpu-num", "--ulysses-degree", dest="gpu_num", type=int, choices=(1, 2, 4), default=1)
+    parser.add_argument("--attention-chunks", type=int, choices=(1, 2), default=PPL_CONFIG["attention_chunks"])
+    parser.add_argument(
+        "--ulysses-sequence-mode",
+        choices=("padded", "valid_only"),
+        default=PPL_CONFIG["ulysses_sequence_mode"],
+    )
     fsdp_group = parser.add_mutually_exclusive_group()
     fsdp_group.add_argument("--enable-fsdp", dest="enable_fsdp", action="store_true")
     fsdp_group.add_argument("--disable-fsdp", dest="enable_fsdp", action="store_false")
@@ -303,6 +315,8 @@ def main() -> None:
         num_inference_steps=request_steps,
         enable_fsdp=args.enable_fsdp,
         online_adaln_cache=online_adaln_cache,
+        attention_chunks=args.attention_chunks,
+        ulysses_sequence_mode=args.ulysses_sequence_mode,
         quantization=args.quantization,
     )
     try:

--- a/examples/minimax_h3/minimax_h3_turbo_lora_h100.py
+++ b/examples/minimax_h3/minimax_h3_turbo_lora_h100.py
@@ -35,6 +35,8 @@ PPL_CONFIG: dict[str, Any] = {
     "device": "cuda:0",
     "enable_fsdp": False,
     "attn_impl": AttnImplType.FLASH_ATTN_4,
+    "attention_chunks": 2,
+    "ulysses_sequence_mode": "valid_only",
 }
 
 PIPELINE_MANIFEST = build_pipeline_manifest(
@@ -64,6 +66,8 @@ def get_pipeline(
     num_inference_steps: int = PPL_CONFIG["num_inference_steps"],
     enable_fsdp: bool | None = PPL_CONFIG["enable_fsdp"],
     attn_impl: AttnImplType | str = PPL_CONFIG["attn_impl"],
+    attention_chunks: int = PPL_CONFIG["attention_chunks"],
+    ulysses_sequence_mode: str = PPL_CONFIG["ulysses_sequence_mode"],
 ) -> MiniMaxH3Pipeline:
     """Load FL2VA and merge Turbo LoRA with the requested GPU parallelism."""
     if parallelism not in {1, 2, 4}:
@@ -79,6 +83,8 @@ def get_pipeline(
         text_encoder_tp_degree=parallelism,
         enable_fsdp=enable_fsdp,
         attn_impl=attn_impl,
+        attention_chunks=attention_chunks,
+        ulysses_sequence_mode=ulysses_sequence_mode,
         lora_path=lora_path,
         lora_strength=lora_strength,
     )
@@ -135,6 +141,12 @@ def run_with_file(
 def main() -> None:
     parser = argparse.ArgumentParser(description="Generate MiniMax H3 Turbo LoRA FL2VA on H100 GPUs")
     parser.add_argument("--gpu-num", "--ulysses-degree", dest="gpu_num", type=int, choices=(1, 2, 4), default=1)
+    parser.add_argument("--attention-chunks", type=int, choices=(1, 2), default=PPL_CONFIG["attention_chunks"])
+    parser.add_argument(
+        "--ulysses-sequence-mode",
+        choices=("padded", "valid_only"),
+        default=PPL_CONFIG["ulysses_sequence_mode"],
+    )
     parser.add_argument("--model-root", default=PPL_CONFIG["model_root"])
     parser.add_argument("--lora-path", default=PPL_CONFIG["lora_path"])
     parser.add_argument("--image", dest="input_image_path", default=PPL_CONFIG["input_image_path"])
@@ -162,6 +174,8 @@ def main() -> None:
         num_inference_steps=args.steps,
         enable_fsdp=args.enable_fsdp,
         attn_impl=args.attn_impl,
+        attention_chunks=args.attention_chunks,
+        ulysses_sequence_mode=args.ulysses_sequence_mode,
     )
     try:
         run(

--- a/telefuser/core/config.py
+++ b/telefuser/core/config.py
@@ -185,6 +185,14 @@ class AttentionConfig:
     scale: float | None = None  # Optional attention scale factor
     dropout: float = 0.0
     is_causal: bool = False
+    attention_chunks: int = 1  # Ulysses/attention overlap chunks; 1 disables overlap
+    ulysses_sequence_mode: str = "padded"  # "valid_only" skips trailing alignment padding
+
+    def __post_init__(self) -> None:
+        if self.attention_chunks not in {1, 2}:
+            raise ValueError("attention_chunks must be 1 or 2")
+        if self.ulysses_sequence_mode not in {"padded", "valid_only"}:
+            raise ValueError("ulysses_sequence_mode must be 'padded' or 'valid_only'")
 
     @classmethod
     def radial_attention(

--- a/telefuser/distributed/ulysses_comm.py
+++ b/telefuser/distributed/ulysses_comm.py
@@ -33,6 +33,24 @@ def _local_head_count(num_heads: int, world_size: int) -> int:
     return num_heads // world_size
 
 
+def _gather_sequence_partition(
+    global_seq_len: int,
+    world_size: int,
+    rank: int,
+    output_sequence_length: int,
+) -> tuple[int, list[int]]:
+    """Return this rank's valid output length and every rank's valid input length."""
+    if output_sequence_length <= 0:
+        raise ValueError("Ulysses gather output sequence length must be positive")
+    if global_seq_len > output_sequence_length * world_size:
+        raise ValueError("Ulysses valid sequence exceeds the padded output capacity")
+    valid_lengths = [
+        max(0, min(output_sequence_length, global_seq_len - destination * output_sequence_length))
+        for destination in range(world_size)
+    ]
+    return valid_lengths[rank], valid_lengths
+
+
 def _wait_async_tensor(tensor: torch.Tensor) -> torch.Tensor:
     """Resolve an asynchronous functional collective tensor."""
     if isinstance(tensor, fc.AsyncCollectiveTensor):
@@ -180,6 +198,107 @@ def ulysses_scatter_qkv(
     def wait() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         result = output.reshape(world_size * local_seq_len, local_heads, 3 * head_dim).unsqueeze(0)
         return result.chunk(3, dim=-1)
+
+    return wait
+
+
+def ulysses_scatter_qkv_qknorm_rope_chunk_async(
+    qkv: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    eps: float,
+    process_group: dist.ProcessGroup,
+    *,
+    local_head_start: int,
+    local_head_count: int,
+) -> Callable[[], tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
+    """Submit one fused Q/K RMSNorm + RoPE + destination-major Ulysses head chunk."""
+    if qkv.ndim != 4 or qkv.shape[1] != 3:
+        raise ValueError("fused Ulysses QKV scatter requires shape [sequence, 3, heads, dim]")
+    _, world_size = _get_distributed_info(process_group)
+    local_seq_len, _, num_heads, head_dim = qkv.shape
+    total_local_heads = _local_head_count(num_heads, world_size)
+    if local_head_start < 0 or local_head_count <= 0 or local_head_start + local_head_count > total_local_heads:
+        raise ValueError("fused Ulysses scatter head chunk falls outside the destination-local heads")
+    if not _can_use_destination_major_kernel(qkv):
+        raise ValueError("fused Ulysses QKV scatter requires eager CUDA FP16/BF16 QKV")
+
+    from telefuser.kernel.triton.ulysses_relayout import pack_qkv_qknorm_rope_destination_major
+
+    packed = pack_qkv_qknorm_rope_destination_major(
+        qkv,
+        q_weight,
+        k_weight,
+        cos_sin_cache,
+        world_size,
+        eps,
+        local_head_start=local_head_start,
+        local_head_count=local_head_count,
+    )
+    output = torch.empty_like(packed.flatten())
+    work = dist.all_to_all_single(output, packed.flatten(), group=process_group, async_op=True)
+
+    def wait() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        work.wait()
+        result = output.reshape(world_size * local_seq_len, local_head_count, 3 * head_dim).unsqueeze(0)
+        return result.chunk(3, dim=-1)
+
+    return wait
+
+
+def ulysses_gather_heads_chunk_async(
+    tensor: torch.Tensor,
+    process_group: dist.ProcessGroup,
+    *,
+    num_heads: int,
+    local_head_start: int,
+    destination: torch.Tensor,
+    zero_tail: bool = False,
+) -> Callable[[], torch.Tensor]:
+    """Submit one valid-only output head chunk and merge it into a padded destination."""
+    if tensor.ndim != 4:
+        raise ValueError("Ulysses head gather requires a 4D tensor")
+    rank, world_size = _get_distributed_info(process_group)
+    batch, global_seq_len, chunk_local_heads, head_dim = tensor.shape
+    total_local_heads = _local_head_count(num_heads, world_size)
+    if local_head_start < 0 or local_head_start + chunk_local_heads > total_local_heads:
+        raise ValueError("Ulysses gather head chunk falls outside the destination-local heads")
+    if not _can_use_destination_major_kernel(tensor):
+        raise ValueError("chunked Ulysses overlap requires CUDA FP16/BF16 attention output")
+    target_seq_len = destination.shape[1]
+    local_seq_len, valid_lengths = _gather_sequence_partition(
+        global_seq_len, world_size, rank, target_seq_len
+    )
+    expected_suffix = (world_size, total_local_heads, head_dim)
+    if destination.shape[0] != batch or tuple(destination.shape[2:]) != expected_suffix:
+        raise ValueError("invalid Ulysses gather destination shape")
+
+    from telefuser.kernel.triton.ulysses_relayout import merge_ulysses_head_chunk
+
+    packed = tensor.permute(1, 0, 2, 3).contiguous()
+    elements_per_token = batch * chunk_local_heads * head_dim
+    input_split_sizes = [length * elements_per_token for length in valid_lengths]
+    output_split_sizes = [local_seq_len * elements_per_token] * world_size
+    output = torch.empty(sum(output_split_sizes), dtype=tensor.dtype, device=tensor.device)
+    work = dist.all_to_all_single(
+        output,
+        packed.flatten(),
+        output_split_sizes=output_split_sizes,
+        input_split_sizes=input_split_sizes,
+        group=process_group,
+        async_op=True,
+    )
+
+    def wait() -> torch.Tensor:
+        work.wait()
+        received = output.reshape(world_size, local_seq_len, batch, chunk_local_heads, head_dim)
+        return merge_ulysses_head_chunk(
+            received,
+            destination,
+            local_head_start=local_head_start,
+            zero_tail=zero_tail,
+        )
 
     return wait
 

--- a/telefuser/distributed/ulysses_comm.py
+++ b/telefuser/distributed/ulysses_comm.py
@@ -267,9 +267,7 @@ def ulysses_gather_heads_chunk_async(
     if not _can_use_destination_major_kernel(tensor):
         raise ValueError("chunked Ulysses overlap requires CUDA FP16/BF16 attention output")
     target_seq_len = destination.shape[1]
-    local_seq_len, valid_lengths = _gather_sequence_partition(
-        global_seq_len, world_size, rank, target_seq_len
-    )
+    local_seq_len, valid_lengths = _gather_sequence_partition(global_seq_len, world_size, rank, target_seq_len)
     expected_suffix = (world_size, total_local_heads, head_dim)
     if destination.shape[0] != batch or tuple(destination.shape[2:]) != expected_suffix:
         raise ValueError("invalid Ulysses gather destination shape")

--- a/telefuser/kernel/triton/indexed_rmsnorm_modulation.py
+++ b/telefuser/kernel/triton/indexed_rmsnorm_modulation.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fused BF16 RMSNorm and indexed AdaLN scale/shift for MiniMax-H3."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _round_bf16_to_fp32(value):
+    bits = value.to(tl.int32, bitcast=True)
+    rounding_bias = 0x7FFF + ((bits >> 16) & 1)
+    rounded_bits = (bits + rounding_bias) & -65536
+    return rounded_bits.to(tl.float32, bitcast=True)
+
+
+@triton.jit
+def _indexed_rmsnorm_scale_shift_bf16_kernel(
+    output_ptr,
+    x_ptr,
+    weight_ptr,
+    shift_ptr,
+    scale_ptr,
+    indices_ptr,
+    hidden_size,
+    parameter_rows,
+    eps,
+    stride_x_row,
+    stride_output_row,
+    stride_shift_row,
+    stride_scale_row,
+    stride_indices,
+    BLOCK_N: tl.constexpr,
+):
+    row = tl.program_id(0)
+    columns = tl.arange(0, BLOCK_N)
+    mask = columns < hidden_size
+    x = tl.load(x_ptr + row * stride_x_row + columns, mask=mask, other=0.0).to(tl.float32)
+    variance = tl.sum(tl.where(mask, x * x, 0.0), axis=0) / hidden_size
+    inv_rms = 1.0 / tl.sqrt(variance + eps)
+    weight = tl.load(weight_ptr + columns, mask=mask, other=1.0).to(tl.float32)
+
+    # Match the standalone RMSNorm BF16 output store/load boundary exactly.
+    normalized = _round_bf16_to_fp32(x * inv_rms * weight)
+    index = tl.load(indices_ptr + row * stride_indices)
+    parameter_mask = mask & (index >= 0) & (index < parameter_rows)
+    shift = tl.load(
+        shift_ptr + index * stride_shift_row + columns,
+        mask=parameter_mask,
+        other=0.0,
+    ).to(tl.float32)
+    scale = tl.load(
+        scale_ptr + index * stride_scale_row + columns,
+        mask=parameter_mask,
+        other=0.0,
+    ).to(tl.float32)
+    one_plus_scale = _round_bf16_to_fp32(1.0 + scale)
+    scaled = _round_bf16_to_fp32(normalized * one_plus_scale)
+    tl.store(output_ptr + row * stride_output_row + columns, scaled + shift, mask=mask)
+
+
+def indexed_rmsnorm_scale_shift_bf16(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    shift: torch.Tensor,
+    scale: torch.Tensor,
+    indices: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    """Return the bit-compatible fusion of RMSNorm and indexed AdaLN modulation."""
+    if x.ndim != 2 or not x.is_contiguous():
+        raise ValueError("fused indexed RMSNorm requires a contiguous 2D input")
+    if x.dtype != torch.bfloat16 or weight.dtype != x.dtype or shift.dtype != x.dtype or scale.dtype != x.dtype:
+        raise TypeError("fused indexed RMSNorm requires matching BF16 tensors")
+    if weight.shape != (x.shape[1],):
+        raise ValueError("RMSNorm weight must match the hidden size")
+    if shift.ndim != 2 or scale.shape != shift.shape or shift.shape[1] != x.shape[1]:
+        raise ValueError("indexed shift/scale must match the input hidden size")
+    if indices.ndim != 1 or indices.numel() != x.shape[0]:
+        raise ValueError("indices must contain one entry per input row")
+    if any(tensor.device != x.device for tensor in (weight, shift, scale, indices)):
+        raise ValueError("all fused indexed RMSNorm tensors must share a device")
+    output = torch.empty_like(x)
+    hidden_size = x.shape[1]
+    block_n = triton.next_power_of_2(hidden_size)
+    _indexed_rmsnorm_scale_shift_bf16_kernel[(x.shape[0],)](
+        output,
+        x,
+        weight,
+        shift,
+        scale,
+        indices,
+        hidden_size,
+        shift.shape[0],
+        eps,
+        x.stride(0),
+        output.stride(0),
+        shift.stride(0),
+        scale.stride(0),
+        indices.stride(0),
+        BLOCK_N=block_n,
+        num_warps=min(max(block_n // 256, 1), 8),
+    )
+    return output

--- a/telefuser/kernel/triton/ulysses_relayout.py
+++ b/telefuser/kernel/triton/ulysses_relayout.py
@@ -197,9 +197,7 @@ def _merge_ulysses_head_chunk_kernel(
     if ZERO_TAIL:
         row = rest % output_sequence
         destination = rest // output_sequence
-        input_vector = (
-            ((destination * sequence + row) * batch + batch_index) * chunk_local_heads + chunk_head
-        )
+        input_vector = ((destination * sequence + row) * batch + batch_index) * chunk_local_heads + chunk_head
         load_mask = mask & (row[:, None] < sequence)
     else:
         row = rest % sequence
@@ -302,10 +300,25 @@ def pack_qkv_qknorm_rope_destination_major(
     total_vectors = rows * world_size * packed_local_heads
     block_n = triton.next_power_of_2(head_dim)
     _pack_qkv_qknorm_rope_destination_major_kernel[(total_vectors,)](
-        output, qkv, q_weight, k_weight, cos_sin_cache, total_vectors, rows,
-        packed_local_heads, total_local_heads, local_head_start, head_dim, rope_dim, eps,
-        qkv.stride(0), qkv.stride(1), qkv.stride(2), cos_sin_cache.stride(0),
-        BLOCK_N=block_n, num_warps=1,
+        output,
+        qkv,
+        q_weight,
+        k_weight,
+        cos_sin_cache,
+        total_vectors,
+        rows,
+        packed_local_heads,
+        total_local_heads,
+        local_head_start,
+        head_dim,
+        rope_dim,
+        eps,
+        qkv.stride(0),
+        qkv.stride(1),
+        qkv.stride(2),
+        cos_sin_cache.stride(0),
+        BLOCK_N=block_n,
+        num_warps=1,
     )
     return output
 
@@ -336,10 +349,21 @@ def merge_ulysses_head_chunk(
     block_head_dim = triton.next_power_of_2(head_dim)
     block_rows = max(1, min(8, 1024 // block_head_dim))
     _merge_ulysses_head_chunk_kernel[(triton.cdiv(total_vectors, block_rows),)](
-        output, tensor, total_vectors, batch, sequence, output.shape[1], total_local_heads,
-        local_head_start, world_size=world_size, chunk_local_heads=chunk_local_heads,
-        head_dim=head_dim, ZERO_TAIL=zero_tail, BLOCK_ROWS=block_rows,
-        BLOCK_HEAD_DIM=block_head_dim, num_warps=8,
+        output,
+        tensor,
+        total_vectors,
+        batch,
+        sequence,
+        output.shape[1],
+        total_local_heads,
+        local_head_start,
+        world_size=world_size,
+        chunk_local_heads=chunk_local_heads,
+        head_dim=head_dim,
+        ZERO_TAIL=zero_tail,
+        BLOCK_ROWS=block_rows,
+        BLOCK_HEAD_DIM=block_head_dim,
+        num_warps=8,
     )
     return output
 

--- a/telefuser/kernel/triton/ulysses_relayout.py
+++ b/telefuser/kernel/triton/ulysses_relayout.py
@@ -17,6 +17,8 @@ def _pack_qkv_destination_major_kernel(
     total_elements,
     rows,
     local_heads,
+    total_local_heads,
+    local_head_start,
     head_dim,
     stride_query_row,
     stride_query_head,
@@ -34,7 +36,7 @@ def _pack_qkv_destination_major_kernel(
     row_slot = head_slot // local_heads
     row = row_slot % rows
     destination = row_slot // rows
-    global_head = destination * local_heads + local_head
+    global_head = destination * total_local_heads + local_head_start + local_head
 
     query = tl.load(
         query_ptr + row * stride_query_row + global_head * stride_query_head + channel,
@@ -52,6 +54,83 @@ def _pack_qkv_destination_major_kernel(
     tl.store(output_ptr + output_base, query, mask=mask)
     tl.store(output_ptr + output_base + head_dim, key, mask=mask)
     tl.store(output_ptr + output_base + 2 * head_dim, value, mask=mask)
+
+
+@triton.jit
+def _round_bf16_to_fp32(value):
+    bits = value.to(tl.int32, bitcast=True)
+    rounding_bias = 0x7FFF + ((bits >> 16) & 1)
+    rounded_bits = (bits + rounding_bias) & -65536
+    return rounded_bits.to(tl.float32, bitcast=True)
+
+
+@triton.jit
+def _pack_qkv_qknorm_rope_destination_major_kernel(
+    output_ptr,
+    qkv_ptr,
+    q_weight_ptr,
+    k_weight_ptr,
+    cache_ptr,
+    total_vectors,
+    rows,
+    packed_local_heads,
+    total_local_heads,
+    local_head_start,
+    head_dim,
+    rope_dim,
+    eps,
+    stride_qkv_row,
+    stride_qkv_section,
+    stride_qkv_head,
+    stride_cache_row,
+    BLOCK_N: tl.constexpr,
+):
+    vector_id = tl.program_id(0)
+    valid_vector = vector_id < total_vectors
+    local_head = vector_id % packed_local_heads
+    row_slot = vector_id // packed_local_heads
+    row = row_slot % rows
+    destination = row_slot // rows
+    global_head = destination * total_local_heads + local_head_start + local_head
+    columns = tl.arange(0, BLOCK_N)
+    mask = valid_vector & (columns < head_dim)
+    q_base = qkv_ptr + row * stride_qkv_row + global_head * stride_qkv_head
+    k_base = q_base + stride_qkv_section
+    v_base = k_base + stride_qkv_section
+
+    query = tl.load(q_base + columns, mask=mask, other=0.0).to(tl.float32)
+    key = tl.load(k_base + columns, mask=mask, other=0.0).to(tl.float32)
+    value = tl.load(v_base + columns, mask=mask, other=0.0)
+    q_weight = tl.load(q_weight_ptr + columns, mask=mask, other=0.0).to(tl.float32)
+    k_weight = tl.load(k_weight_ptr + columns, mask=mask, other=0.0).to(tl.float32)
+    q_inv_rms = tl.rsqrt(tl.sum(query * query, axis=0) / head_dim + eps)
+    k_inv_rms = tl.rsqrt(tl.sum(key * key, axis=0) / head_dim + eps)
+    query = _round_bf16_to_fp32(query * q_inv_rms * q_weight)
+    key = _round_bf16_to_fp32(key * k_inv_rms * k_weight)
+
+    rope_half = rope_dim // 2
+    rotary_mask = mask & (columns < rope_dim)
+    partner_columns = tl.where(columns < rope_half, columns + rope_half, columns - rope_half)
+    q_partner = tl.load(q_base + partner_columns, mask=rotary_mask, other=0.0).to(tl.float32)
+    k_partner = tl.load(k_base + partner_columns, mask=rotary_mask, other=0.0).to(tl.float32)
+    q_partner_weight = tl.load(q_weight_ptr + partner_columns, mask=rotary_mask, other=0.0).to(tl.float32)
+    k_partner_weight = tl.load(k_weight_ptr + partner_columns, mask=rotary_mask, other=0.0).to(tl.float32)
+    q_partner = _round_bf16_to_fp32(q_partner * q_inv_rms * q_partner_weight)
+    k_partner = _round_bf16_to_fp32(k_partner * k_inv_rms * k_partner_weight)
+    frequency_column = columns % rope_half
+    cosine = tl.load(cache_ptr + row * stride_cache_row + frequency_column, mask=rotary_mask, other=1.0).to(tl.float32)
+    sine = tl.load(
+        cache_ptr + row * stride_cache_row + rope_half + frequency_column,
+        mask=rotary_mask,
+        other=0.0,
+    ).to(tl.float32)
+    query = tl.where(columns < rope_half, query * cosine - q_partner * sine, query * cosine + q_partner * sine)
+    key = tl.where(columns < rope_half, key * cosine - k_partner * sine, key * cosine + k_partner * sine)
+
+    output_base = vector_id * (3 * head_dim)
+    tl.store(output_ptr + output_base + columns, query, mask=mask)
+    tl.store(output_ptr + output_base + head_dim + columns, key, mask=mask)
+    tl.store(output_ptr + output_base + 2 * head_dim + columns, value, mask=mask)
 
 
 @triton.jit
@@ -89,15 +168,69 @@ def _merge_ulysses_heads_kernel(
     )
 
 
+@triton.jit
+def _merge_ulysses_head_chunk_kernel(
+    output_ptr,
+    input_ptr,
+    total_vectors,
+    batch,
+    sequence,
+    output_sequence,
+    total_local_heads,
+    local_head_start,
+    world_size: tl.constexpr,
+    chunk_local_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    ZERO_TAIL: tl.constexpr,
+    BLOCK_ROWS: tl.constexpr,
+    BLOCK_HEAD_DIM: tl.constexpr,
+):
+    vector_ids = tl.program_id(0) * BLOCK_ROWS + tl.arange(0, BLOCK_ROWS)
+    channels = tl.arange(0, BLOCK_HEAD_DIM)
+    vector_mask = vector_ids < total_vectors
+    channel_mask = channels < head_dim
+    mask = vector_mask[:, None] & channel_mask[None, :]
+    chunk_head = vector_ids % chunk_local_heads
+    rest = vector_ids // chunk_local_heads
+    batch_index = rest % batch
+    rest //= batch
+    if ZERO_TAIL:
+        row = rest % output_sequence
+        destination = rest // output_sequence
+        input_vector = (
+            ((destination * sequence + row) * batch + batch_index) * chunk_local_heads + chunk_head
+        )
+        load_mask = mask & (row[:, None] < sequence)
+    else:
+        row = rest % sequence
+        destination = rest // sequence
+        input_vector = vector_ids
+        load_mask = mask
+    output_head = destination * total_local_heads + local_head_start + chunk_head
+    values = tl.load(
+        input_ptr + input_vector[:, None] * head_dim + channels[None, :],
+        mask=load_mask,
+        other=0.0,
+    )
+    output_base = (batch_index * output_sequence + row) * (world_size * total_local_heads) + output_head
+    tl.store(output_ptr + output_base[:, None] * head_dim + channels[None, :], values, mask=mask)
+
+
 def pack_qkv_destination_major(
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
     world_size: int,
+    *,
+    local_head_start: int = 0,
+    local_head_count: int | None = None,
 ) -> torch.Tensor:
     """Pack 3D Q/K/V directly as ``[destination, row, local_head, 3 * dim]``."""
     rows, global_heads, head_dim = query.shape
-    local_heads = global_heads // world_size
+    total_local_heads = global_heads // world_size
+    local_heads = total_local_heads - local_head_start if local_head_count is None else local_head_count
+    if local_head_start < 0 or local_heads <= 0 or local_head_start + local_heads > total_local_heads:
+        raise ValueError("Ulysses QKV head chunk falls outside the destination-local heads")
     output = torch.empty(
         world_size,
         rows,
@@ -106,7 +239,7 @@ def pack_qkv_destination_major(
         dtype=query.dtype,
         device=query.device,
     )
-    total_elements = rows * global_heads * head_dim
+    total_elements = rows * world_size * local_heads * head_dim
     if total_elements == 0:
         return output
     block_size = 1024
@@ -118,6 +251,8 @@ def pack_qkv_destination_major(
         total_elements,
         rows,
         local_heads,
+        total_local_heads,
+        local_head_start,
         head_dim,
         query.stride(0),
         query.stride(1),
@@ -127,6 +262,84 @@ def pack_qkv_destination_major(
         value.stride(1),
         BLOCK_SIZE=block_size,
         num_warps=8,
+    )
+    return output
+
+
+def pack_qkv_qknorm_rope_destination_major(
+    qkv: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    world_size: int,
+    eps: float,
+    *,
+    local_head_start: int = 0,
+    local_head_count: int | None = None,
+) -> torch.Tensor:
+    """Normalize/rotate Q/K and pack Q/K/V directly for Ulysses all-to-all."""
+    if qkv.ndim != 4 or qkv.shape[1] != 3:
+        raise ValueError("fused Ulysses QKV pack requires shape [rows, 3, heads, dim]")
+    rows, _, global_heads, head_dim = qkv.shape
+    if world_size <= 0 or global_heads % world_size:
+        raise ValueError("QKV heads must divide the Ulysses world size")
+    if q_weight.shape != (head_dim,) or k_weight.shape != (head_dim,):
+        raise ValueError("Q/K RMSNorm weights must match the QKV head dimension")
+    if cos_sin_cache.ndim != 2 or cos_sin_cache.shape[0] != rows:
+        raise ValueError("RoPE cache must have shape [rows, rotary_dim]")
+    rope_dim = cos_sin_cache.shape[1]
+    if rope_dim <= 0 or rope_dim % 2 or rope_dim > head_dim:
+        raise ValueError("RoPE dimension must be positive, even, and no larger than head_dim")
+    if qkv.dtype != torch.bfloat16 or q_weight.dtype != torch.bfloat16 or k_weight.dtype != torch.bfloat16:
+        raise ValueError("fused Ulysses QKV pack requires BF16 QKV and RMSNorm weights")
+    if not qkv.is_cuda or not q_weight.is_cuda or not k_weight.is_cuda or not cos_sin_cache.is_cuda:
+        raise ValueError("fused Ulysses QKV pack requires CUDA tensors")
+    total_local_heads = global_heads // world_size
+    packed_local_heads = total_local_heads - local_head_start if local_head_count is None else local_head_count
+    if local_head_start < 0 or packed_local_heads <= 0 or local_head_start + packed_local_heads > total_local_heads:
+        raise ValueError("fused Ulysses QKV head chunk falls outside the destination-local heads")
+    output = torch.empty(world_size, rows, packed_local_heads, 3 * head_dim, dtype=qkv.dtype, device=qkv.device)
+    total_vectors = rows * world_size * packed_local_heads
+    block_n = triton.next_power_of_2(head_dim)
+    _pack_qkv_qknorm_rope_destination_major_kernel[(total_vectors,)](
+        output, qkv, q_weight, k_weight, cos_sin_cache, total_vectors, rows,
+        packed_local_heads, total_local_heads, local_head_start, head_dim, rope_dim, eps,
+        qkv.stride(0), qkv.stride(1), qkv.stride(2), cos_sin_cache.stride(0),
+        BLOCK_N=block_n, num_warps=1,
+    )
+    return output
+
+
+def merge_ulysses_head_chunk(
+    tensor: torch.Tensor,
+    output: torch.Tensor,
+    *,
+    local_head_start: int,
+    zero_tail: bool = False,
+) -> torch.Tensor:
+    """Merge one received head chunk into a shared full output tensor."""
+    world_size, sequence, batch, chunk_local_heads, head_dim = tensor.shape
+    if output.ndim != 5 or not output.is_contiguous():
+        raise ValueError("Ulysses chunk destination must be a contiguous 5D tensor")
+    total_local_heads = output.shape[3]
+    if (
+        output.shape[0] != batch
+        or output.shape[1] < sequence
+        or output.shape[2] != world_size
+        or output.shape[-1] != head_dim
+    ):
+        raise ValueError("invalid Ulysses chunk destination shape")
+    if local_head_start < 0 or local_head_start + chunk_local_heads > total_local_heads:
+        raise ValueError("Ulysses gather head chunk falls outside the destination tensor")
+    written_sequence = output.shape[1] if zero_tail else sequence
+    total_vectors = world_size * written_sequence * batch * chunk_local_heads
+    block_head_dim = triton.next_power_of_2(head_dim)
+    block_rows = max(1, min(8, 1024 // block_head_dim))
+    _merge_ulysses_head_chunk_kernel[(triton.cdiv(total_vectors, block_rows),)](
+        output, tensor, total_vectors, batch, sequence, output.shape[1], total_local_heads,
+        local_head_start, world_size=world_size, chunk_local_heads=chunk_local_heads,
+        head_dim=head_dim, ZERO_TAIL=zero_tail, BLOCK_ROWS=block_rows,
+        BLOCK_HEAD_DIM=block_head_dim, num_warps=8,
     )
     return output
 

--- a/telefuser/models/minimax_h3_dit.py
+++ b/telefuser/models/minimax_h3_dit.py
@@ -27,7 +27,12 @@ from telefuser.distributed.device_mesh import (
     get_ulysses_world_size,
 )
 from telefuser.distributed.parallel_shard import sequence_parallel_shard, sequence_parallel_unshard
-from telefuser.distributed.ulysses_comm import ulysses_gather_heads_destination_major, ulysses_scatter_heads
+from telefuser.distributed.ulysses_comm import (
+    ulysses_gather_heads_chunk_async,
+    ulysses_gather_heads_destination_major,
+    ulysses_scatter_heads,
+    ulysses_scatter_qkv_qknorm_rope_chunk_async,
+)
 from telefuser.feature_cache import AdaTaylorCacheCalibrator, NoOpCache
 from telefuser.ops import RMSNorm, apply_qk_norm_rope_neox, indexed_gate, indexed_scale_shift, silu_and_mul_reuse_input
 from telefuser.ops.attention import SparseAttentionState, attention
@@ -53,6 +58,60 @@ MINIMAX_H3_FP32_PARAM_NAMES = frozenset(
     }
 )
 MINIMAX_H3_FP32_BUFFER_NAMES = frozenset({"rope.inv_freq"})
+
+
+def _ulysses_head_chunk_ranges(local_heads: int, chunks: int = 2) -> tuple[tuple[int, int], ...]:
+    """Return balanced, non-empty destination-local head ranges."""
+    if local_heads <= 0 or chunks <= 0 or chunks > local_heads:
+        raise ValueError("invalid Ulysses attention head chunks")
+    base, remainder = divmod(local_heads, chunks)
+    ranges = []
+    start = 0
+    for index in range(chunks):
+        count = base + (1 if index < remainder else 0)
+        ranges.append((start, count))
+        start += count
+    return tuple(ranges)
+
+
+def _can_run_fused_ulysses_attention(
+    qkv: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    attention_config: AttentionConfig | None,
+    sequence_lengths: list[int],
+    rope_cos_sin_cache: torch.Tensor | None,
+    use_ulysses: bool,
+    ulysses_world_size: int,
+) -> bool:
+    """Check whether the lossless fused MiniMax-H3 Ulysses path is supported."""
+    return (
+        use_ulysses
+        and not torch.compiler.is_compiling()
+        and qkv.is_cuda
+        and qkv.dtype == torch.bfloat16
+        and qkv.ndim == 4
+        and qkv.shape[1] == 3
+        and qkv.stride(-1) == 1
+        and q_weight.is_cuda
+        and k_weight.is_cuda
+        and q_weight.dtype == k_weight.dtype == qkv.dtype
+        and q_weight.is_contiguous()
+        and k_weight.is_contiguous()
+        and rope_cos_sin_cache is not None
+        and rope_cos_sin_cache.is_cuda
+        and rope_cos_sin_cache.ndim == 2
+        and rope_cos_sin_cache.shape[0] == qkv.shape[0]
+        and rope_cos_sin_cache.stride(-1) == 1
+        and attention_config is not None
+        and attention_config.attn_impl == AttnImplType.FLASH_ATTN_4
+        and len(sequence_lengths) == 2
+        and sum(sequence_lengths) == qkv.shape[0] * ulysses_world_size
+        and sequence_lengths[0] > 0
+        and 0 < sequence_lengths[1] < 64
+        and sequence_lengths[0] > sequence_lengths[1]
+        and qkv.shape[0] % 64 == 0
+    )
 
 
 @dataclass(frozen=True)
@@ -512,97 +571,165 @@ class MiniMaxH3Attention(nn.Module):
         query, key, value = qkv.unbind(dim=1)
         group = self.ulysses_group
         use_ulysses = group is not None and dist.get_world_size(group) > 1
-        if use_ulysses:
-            value_wait = ulysses_scatter_heads(
-                value.unsqueeze(0), group, tag="v", barrier=False, communicator=self.ulysses_communicator
+        world_size = dist.get_world_size(group) if use_ulysses else 1
+        local_heads = self.num_heads // world_size
+        use_fused_ulysses = _can_run_fused_ulysses_attention(
+            qkv,
+            self.q_norm.weight,
+            self.k_norm.weight,
+            attention_config,
+            sequence_lengths,
+            rope_cos_sin_cache,
+            use_ulysses,
+            world_size,
+        )
+        use_fused_ulysses = (
+            use_fused_ulysses
+            and attention_config is not None
+            and attention_config.attention_chunks <= local_heads
+        )
+        if use_fused_ulysses:
+            chunks = attention_config.attention_chunks
+            head_ranges = _ulysses_head_chunk_ranges(local_heads, chunks=chunks)
+            valid_only = attention_config.ulysses_sequence_mode == "valid_only"
+            destination = torch.empty(
+                1,
+                sequence,
+                world_size,
+                local_heads,
+                self.head_dim,
+                dtype=value.dtype,
+                device=value.device,
             )
-        if rope_cos_sin_cache is not None:
-            query, key = apply_qk_norm_rope_neox(
-                query,
-                key,
-                self.q_norm.weight,
-                self.k_norm.weight,
-                rope_cos_sin_cache,
-                eps=self.q_norm.eps,
-            )
-        else:
-            query = self.q_norm(query)
-            key = self.k_norm(key)
-        query = query.unsqueeze(0)
-        key = key.unsqueeze(0)
-        value = value.unsqueeze(0)
-        if use_ulysses:
-            query_wait = ulysses_scatter_heads(
-                query, group, tag="q", barrier=False, communicator=self.ulysses_communicator
-            )
-            key_wait = ulysses_scatter_heads(key, group, tag="k", communicator=self.ulysses_communicator)
-            query = query_wait()
-            key = key_wait()
-            value = value_wait()
-        optimized_impls = {AttnImplType.SAGE_ATTN_2_8_8_SM90, AttnImplType.SOL_ATTN}
-        if attention_config is not None and attention_config.attn_impl in optimized_impls:
-            total_tokens = query.shape[1]
-            live_tokens = self._live_tokens(sequence_lengths, total_tokens)
-            live_query = query[:, :live_tokens].contiguous()
-            live_key = key[:, :live_tokens].contiguous()
-            live_value = value[:, :live_tokens].contiguous()
-            scales = None
-            runtime_attention_config = attention_config
-            runtime_sparse_state = sparse_state
-            if attention_config.attn_impl == AttnImplType.SOL_ATTN:
-                if sparse_state is None:
-                    raise RuntimeError("MiniMax H3 Sol-Attn requires sparse runtime state")
-                if not 0 <= prefix_tokens <= live_tokens:
-                    raise ValueError("MiniMax H3 Sol-Attn prefix must be within the live packed sequence")
-                sol_query, sol_key, sol_value, scales = self._prepare_sol_qkv(
-                    live_query,
-                    live_key,
-                    live_value,
-                    sparse_state,
+            scatter_waiters = [
+                ulysses_scatter_qkv_qknorm_rope_chunk_async(
+                    qkv,
+                    self.q_norm.weight,
+                    self.k_norm.weight,
+                    rope_cos_sin_cache,
+                    self.q_norm.eps,
+                    group,
+                    local_head_start=start,
+                    local_head_count=count,
                 )
-                if sparse_state.should_use_dense():
-                    runtime_attention_config = AttentionConfig.dense_attention(AttnImplType.FLASH_ATTN_4)
-                    runtime_sparse_state = None
-            else:
-                sol_query, sol_key, sol_value = live_query, live_key, live_value
-            live_output = attention(
-                sol_query,
-                sol_key,
-                sol_value,
-                attention_config=runtime_attention_config,
-                sparse_state=runtime_sparse_state,
-                scale=self.head_dim**-0.5,
-                q_scale=None if scales is None else scales[0],
-                k_scale=None if scales is None else scales[1],
-                v_scale=None if scales is None else scales[2],
-                sink_start=0,
-                sink_tokens=prefix_tokens,
-            )
-            if self._is_sol_active(sparse_state) and prefix_tokens:
-                dense_prefix = F.scaled_dot_product_attention(
-                    live_query[:, :prefix_tokens].transpose(1, 2),
-                    live_key.transpose(1, 2),
-                    live_value.transpose(1, 2),
+                for start, count in head_ranges
+            ]
+            gather_waiters = []
+            for (start, _), scatter_wait in zip(head_ranges, scatter_waiters, strict=True):
+                query_chunk, key_chunk, value_chunk = scatter_wait()
+                output_chunk = attention(
+                    query_chunk,
+                    key_chunk,
+                    value_chunk,
+                    attention_config=attention_config,
                     scale=self.head_dim**-0.5,
-                ).transpose(1, 2)
-                live_output = torch.cat((dense_prefix, live_output[:, prefix_tokens:]), dim=1)
-            if live_tokens == total_tokens:
-                output = live_output
-            else:
-                output = torch.zeros_like(query)
-                output[:, :live_tokens].copy_(live_output)
+                    sequence_lengths=sequence_lengths,
+                    cu_seqlens=cu_seqlens,
+                    fixed_valid=True,
+                    pad_fixed_valid_output=not valid_only,
+                )
+                gather_waiters.append(
+                    ulysses_gather_heads_chunk_async(
+                        output_chunk,
+                        group,
+                        num_heads=self.num_heads,
+                        local_head_start=start,
+                        destination=destination,
+                        zero_tail=valid_only,
+                    )
+                )
+            for gather_wait in gather_waiters:
+                gather_wait()
+            output = destination.flatten(2, 3)
         else:
-            output = attention(
-                query,
-                key,
-                value,
-                attention_config=attention_config,
-                scale=self.head_dim**-0.5,
-                sequence_lengths=sequence_lengths,
-                cu_seqlens=cu_seqlens,
-            )
-        if use_ulysses:
-            output = ulysses_gather_heads_destination_major(output, group, num_heads=self.num_heads)()
+            if use_ulysses:
+                value_wait = ulysses_scatter_heads(
+                    value.unsqueeze(0), group, tag="v", barrier=False, communicator=self.ulysses_communicator
+                )
+            if rope_cos_sin_cache is not None:
+                query, key = apply_qk_norm_rope_neox(
+                    query,
+                    key,
+                    self.q_norm.weight,
+                    self.k_norm.weight,
+                    rope_cos_sin_cache,
+                    eps=self.q_norm.eps,
+                )
+            else:
+                query = self.q_norm(query)
+                key = self.k_norm(key)
+            query = query.unsqueeze(0)
+            key = key.unsqueeze(0)
+            value = value.unsqueeze(0)
+            if use_ulysses:
+                query_wait = ulysses_scatter_heads(
+                    query, group, tag="q", barrier=False, communicator=self.ulysses_communicator
+                )
+                key_wait = ulysses_scatter_heads(key, group, tag="k", communicator=self.ulysses_communicator)
+                query = query_wait()
+                key = key_wait()
+                value = value_wait()
+            optimized_impls = {AttnImplType.SAGE_ATTN_2_8_8_SM90, AttnImplType.SOL_ATTN}
+            if attention_config is not None and attention_config.attn_impl in optimized_impls:
+                total_tokens = query.shape[1]
+                live_tokens = self._live_tokens(sequence_lengths, total_tokens)
+                live_query = query[:, :live_tokens].contiguous()
+                live_key = key[:, :live_tokens].contiguous()
+                live_value = value[:, :live_tokens].contiguous()
+                scales = None
+                runtime_attention_config = attention_config
+                runtime_sparse_state = sparse_state
+                if attention_config.attn_impl == AttnImplType.SOL_ATTN:
+                    if sparse_state is None:
+                        raise RuntimeError("MiniMax H3 Sol-Attn requires sparse runtime state")
+                    if not 0 <= prefix_tokens <= live_tokens:
+                        raise ValueError("MiniMax H3 Sol-Attn prefix must be within the live packed sequence")
+                    sol_query, sol_key, sol_value, scales = self._prepare_sol_qkv(
+                        live_query, live_key, live_value, sparse_state
+                    )
+                    if sparse_state.should_use_dense():
+                        runtime_attention_config = AttentionConfig.dense_attention(AttnImplType.FLASH_ATTN_4)
+                        runtime_sparse_state = None
+                else:
+                    sol_query, sol_key, sol_value = live_query, live_key, live_value
+                live_output = attention(
+                    sol_query,
+                    sol_key,
+                    sol_value,
+                    attention_config=runtime_attention_config,
+                    sparse_state=runtime_sparse_state,
+                    scale=self.head_dim**-0.5,
+                    q_scale=None if scales is None else scales[0],
+                    k_scale=None if scales is None else scales[1],
+                    v_scale=None if scales is None else scales[2],
+                    sink_start=0,
+                    sink_tokens=prefix_tokens,
+                )
+                if self._is_sol_active(sparse_state) and prefix_tokens:
+                    dense_prefix = F.scaled_dot_product_attention(
+                        live_query[:, :prefix_tokens].transpose(1, 2),
+                        live_key.transpose(1, 2),
+                        live_value.transpose(1, 2),
+                        scale=self.head_dim**-0.5,
+                    ).transpose(1, 2)
+                    live_output = torch.cat((dense_prefix, live_output[:, prefix_tokens:]), dim=1)
+                if live_tokens == total_tokens:
+                    output = live_output
+                else:
+                    output = torch.zeros_like(query)
+                    output[:, :live_tokens].copy_(live_output)
+            else:
+                output = attention(
+                    query,
+                    key,
+                    value,
+                    attention_config=attention_config,
+                    scale=self.head_dim**-0.5,
+                    sequence_lengths=sequence_lengths,
+                    cu_seqlens=cu_seqlens,
+                )
+            if use_ulysses:
+                output = ulysses_gather_heads_destination_major(output, group, num_heads=self.num_heads)()
         output = self.out_proj(output[0].reshape(sequence, self.inner_dim))
         if self.tp_group is not None:
             all_reduce_sum_((output,), group=self.tp_group)
@@ -689,6 +816,45 @@ def _modulate(
     return indexed_scale_shift(hidden, shift, scale, indices)
 
 
+def _norm_modulate(
+    norm: RMSNorm,
+    hidden: torch.Tensor,
+    shift: torch.Tensor,
+    scale: torch.Tensor,
+    indices: torch.Tensor,
+) -> torch.Tensor:
+    """Run the bit-compatible RMSNorm + indexed AdaLN fusion when supported."""
+    weight = norm.weight
+    use_fused = (
+        not torch.compiler.is_compiling()
+        and hidden.device.type == "cuda"
+        and hidden.dtype == torch.bfloat16
+        and hidden.ndim == 2
+        and hidden.is_contiguous()
+        and weight is not None
+        and weight.dtype == shift.dtype == scale.dtype == hidden.dtype
+        and weight.is_contiguous()
+        and shift.ndim == scale.ndim == 2
+        and shift.stride(-1) == scale.stride(-1) == 1
+        and indices.ndim == 1
+        and indices.device == hidden.device
+    )
+    if use_fused:
+        from telefuser.kernel.triton.indexed_rmsnorm_modulation import (
+            indexed_rmsnorm_scale_shift_bf16,
+        )
+
+        return indexed_rmsnorm_scale_shift_bf16(
+            hidden,
+            weight,
+            shift,
+            scale,
+            indices.contiguous(),
+            norm.eps,
+        )
+    return _modulate(norm(hidden), shift, scale, indices)
+
+
 class MiniMaxH3TokenRefinerBlock(nn.Module):
     def __init__(self, config: MiniMaxH3DiTConfig) -> None:
         super().__init__()
@@ -767,7 +933,7 @@ class MiniMaxH3DiTBlock(nn.Module):
             adaln_params = self.adaln_proj(adaln_input)
         shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = adaln_params
         residual = hidden
-        value = _modulate(self.norm1(hidden), shift_msa, scale_msa, combined_indices)
+        value = _norm_modulate(self.norm1, hidden, shift_msa, scale_msa, combined_indices)
         value = self.attn(
             value,
             sequence_lengths=sequence_lengths,
@@ -779,7 +945,7 @@ class MiniMaxH3DiTBlock(nn.Module):
         )
         hidden = indexed_gate(residual, gate_msa, value, combined_indices)
         residual = hidden
-        value = _modulate(self.norm2(hidden), shift_mlp, scale_mlp, combined_indices)
+        value = _norm_modulate(self.norm2, hidden, shift_mlp, scale_mlp, combined_indices)
         value = self.mlp(value)
         return indexed_gate(residual, gate_mlp, value, combined_indices)
 
@@ -805,7 +971,7 @@ class MiniMaxH3FinalLayer(nn.Module):
                 raise ValueError("adaln_input is required when no cached AdaLN parameters are supplied.")
             adaln_params = self.adaln_proj(adaln_input)
         shift, scale = adaln_params
-        hidden = _modulate(self.norm(hidden), shift, scale, inverse_indices).float()
+        hidden = _norm_modulate(self.norm, hidden, shift, scale, inverse_indices).float()
         return self.video_out(hidden), self.audio_out(hidden)
 
 

--- a/telefuser/models/minimax_h3_dit.py
+++ b/telefuser/models/minimax_h3_dit.py
@@ -584,9 +584,7 @@ class MiniMaxH3Attention(nn.Module):
             world_size,
         )
         use_fused_ulysses = (
-            use_fused_ulysses
-            and attention_config is not None
-            and attention_config.attention_chunks <= local_heads
+            use_fused_ulysses and attention_config is not None and attention_config.attention_chunks <= local_heads
         )
         if use_fused_ulysses:
             chunks = attention_config.attention_chunks

--- a/telefuser/ops/attention/attention_impl.py
+++ b/telefuser/ops/attention/attention_impl.py
@@ -86,13 +86,33 @@ def _packed_flash_attention4(
     scale: float | None,
     is_causal: bool,
     return_lse: bool,
+    fixed_valid: bool,
+    pad_fixed_valid_output: bool,
     kwargs: dict[str, Any],
 ) -> Tensor | tuple[Tensor, Tensor]:
-    """Run FlashAttention 4 varlen over sequences packed on the BSND axis."""
+    """Run FlashAttention 4 over packed input, optionally skipping trailing padding."""
     if q.shape != k.shape or q.shape != v.shape or q.ndim != 4 or q.shape[0] != 1:
         raise ValueError("packed FlashAttention requires matching Q/K/V tensors with shape [1, sequence, heads, dim]")
     if any(length <= 0 for length in sequence_lengths) or sum(sequence_lengths) != q.shape[1]:
         raise ValueError("packed FlashAttention lengths must be positive and sum to the packed sequence dimension")
+    if fixed_valid:
+        if return_lse:
+            raise ValueError("fixed-valid packed FlashAttention does not support return_lse")
+        valid_length = sequence_lengths[0]
+        result = flash_attn4(
+            q[:, :valid_length],
+            k[:, :valid_length],
+            v[:, :valid_length],
+            softmax_scale=scale,
+            causal=is_causal,
+            return_lse=False,
+            **kwargs,
+        )
+        valid_output = result[0] if isinstance(result, tuple) else result
+        if not pad_fixed_valid_output:
+            return valid_output
+        padding = q.shape[1] - valid_length
+        return F.pad(valid_output, (0, 0, 0, 0, 0, padding)) if padding else valid_output
     if cu_seqlens is None:
         cumulative = [0]
         for length in sequence_lengths:
@@ -195,6 +215,8 @@ def attention(
     v_scale: Tensor | None = None,
     sink_start: int | None = None,
     sink_tokens: int = 0,
+    fixed_valid: bool = False,
+    pad_fixed_valid_output: bool = True,
     **kwargs: Any,
 ) -> Tensor | tuple[Tensor, Tensor]:
     """Unified attention function.
@@ -214,6 +236,8 @@ def attention(
         return_lse: Return log-sum-exp values.
         sequence_lengths: Length of each sequence packed along the sequence axis.
         cu_seqlens: Optional precomputed cumulative sequence lengths for varlen kernels.
+        fixed_valid: Run fixed-shape FA4 only on the first valid packed sequence.
+        pad_fixed_valid_output: Restore trailing padding after fixed-valid FA4.
         sink_start: Start of the exact KV sink used by Sol-Attn.
         sink_tokens: Number of exact KV sink tokens used by Sol-Attn.
         **kwargs: Implementation-specific arguments.
@@ -304,7 +328,7 @@ def attention(
     if attn_impl == AttnImplType.FLASH_ATTN_4 and FLASH_ATTN_4_AVAILABLE and flash_attn4 is not None:
         if sequence_lengths is None:
             result = flash_attn4(q, k, v, softmax_scale=scale, causal=is_causal, return_lse=return_lse, **kwargs)
-        elif flash_attn4_varlen is not None:
+        elif fixed_valid or flash_attn4_varlen is not None:
             if attn_mask is not None or current_layout != "BSND":
                 raise ValueError("packed FlashAttention requires BSND layout without an attention mask")
             result = _packed_flash_attention4(
@@ -316,6 +340,8 @@ def attention(
                 scale=scale,
                 is_causal=is_causal,
                 return_lse=return_lse,
+                fixed_valid=fixed_valid,
+                pad_fixed_valid_output=pad_fixed_valid_output,
                 kwargs=kwargs,
             )
         else:

--- a/telefuser/pipelines/minimax_h3/denoising.py
+++ b/telefuser/pipelines/minimax_h3/denoising.py
@@ -3,11 +3,13 @@
 
 from __future__ import annotations
 
+import math
 import time
 from dataclasses import dataclass
 from typing import Any
 
 import torch
+import torch.distributed as dist
 
 from telefuser.core.base_stage import BaseStage, with_model_offload
 from telefuser.core.config import ModelRuntimeConfig, WeightOffloadType
@@ -39,6 +41,66 @@ from .vae import MiniMaxH3PreparedCondition
 
 MINIMAX_H3_IMGVID_COND_TIMESTEP = 0.999
 MINIMAX_H3_AUDIO_REF_COND_TIMESTEP = 1.0
+
+
+@dataclass(frozen=True)
+class MiniMaxH3DiTCacheConfig:
+    """Configure optional reuse of the previous MiniMax H3 DiT velocity."""
+
+    mode: str = "off"
+    start_ratio: float = 0.2
+    end_ratio: float = 0.8
+    refresh_interval: int = 2
+    max_consecutive_reuse: int = 1
+    threshold: float | None = None
+
+    def __post_init__(self) -> None:
+        normalized_mode = str(self.mode).strip().lower().replace("_", "-")
+        if normalized_mode == "conservative":
+            normalized_mode = "velocity"
+        if normalized_mode not in {"off", "probe", "velocity"}:
+            raise ValueError(
+                "MiniMax H3 DiT cache mode must be 'off', 'probe', 'velocity', or 'conservative'"
+            )
+        object.__setattr__(self, "mode", normalized_mode)
+        if not math.isfinite(self.start_ratio) or not 0.0 <= self.start_ratio < 1.0:
+            raise ValueError("MiniMax H3 DiT cache start_ratio must be in [0, 1)")
+        if not math.isfinite(self.end_ratio) or not 0.0 < self.end_ratio <= 1.0:
+            raise ValueError("MiniMax H3 DiT cache end_ratio must be in (0, 1]")
+        if self.start_ratio >= self.end_ratio:
+            raise ValueError("MiniMax H3 DiT cache start_ratio must be smaller than end_ratio")
+        if (
+            not isinstance(self.refresh_interval, int)
+            or isinstance(self.refresh_interval, bool)
+            or self.refresh_interval < 2
+        ):
+            raise ValueError("MiniMax H3 DiT cache refresh_interval must be an integer of at least 2")
+        if (
+            not isinstance(self.max_consecutive_reuse, int)
+            or isinstance(self.max_consecutive_reuse, bool)
+            or self.max_consecutive_reuse < 1
+        ):
+            raise ValueError("MiniMax H3 DiT cache max_consecutive_reuse must be a positive integer")
+        if self.threshold is not None and (not math.isfinite(self.threshold) or self.threshold < 0.0):
+            raise ValueError("MiniMax H3 DiT cache threshold must be a finite non-negative number")
+
+
+def _dit_cache_step_is_candidate(step: int, total_steps: int, config: MiniMaxH3DiTCacheConfig) -> bool:
+    """Return a deterministic velocity-reuse schedule shared by every rank."""
+    if config.mode == "off" or total_steps < 3:
+        return False
+    start = max(1, int(math.floor(total_steps * config.start_ratio)))
+    stop = min(total_steps - 1, int(math.ceil(total_steps * config.end_ratio)))
+    if not start <= step < stop:
+        return False
+    # Refresh at the start of each interval; later steps may reuse its velocity.
+    return (step - start) % config.refresh_interval != 0
+
+
+def _relative_l1_delta(current: torch.Tensor, reference: torch.Tensor) -> torch.Tensor:
+    numerator = torch.mean(torch.abs(current - reference))
+    denominator = torch.mean(torch.abs(reference)).clamp_min(1e-6)
+    return numerator / denominator
 
 
 @torch.inference_mode()
@@ -244,6 +306,7 @@ class MiniMaxH3DenoisingStage(BaseStage):
         text: MiniMaxH3TextCondition | dict[str, torch.Tensor],
         conditions: list[MiniMaxH3PreparedCondition] | list[dict[str, Any]],
         num_inference_steps: int,
+        dit_cache_config: MiniMaxH3DiTCacheConfig | None = None,
         _transport_video: bool = False,
     ) -> MiniMaxH3DenoiseResult:
         self._ensure_online_quantized()
@@ -261,6 +324,11 @@ class MiniMaxH3DenoisingStage(BaseStage):
         seed = 42 if plan.seed is None else int(plan.seed)
         if num_inference_steps < 2:
             raise ValueError("num_inference_steps must be at least 2")
+        cache_config = MiniMaxH3DiTCacheConfig() if dit_cache_config is None else dit_cache_config
+        if not isinstance(cache_config, MiniMaxH3DiTCacheConfig):
+            raise TypeError("dit_cache_config must be a MiniMaxH3DiTCacheConfig")
+        if cache_config.mode != "off" and self.model_runtime_config.feature_cache_config.enabled:
+            raise ValueError("MiniMax H3 Conservative DiT cache cannot be combined with Feature Cache")
 
         ref_blocks: list[dict[str, object]] | None = None
         if plan.task == "ref2va":
@@ -470,6 +538,19 @@ class MiniMaxH3DenoisingStage(BaseStage):
         audio_denoised_scratch = torch.empty_like(audio_rows[audio_target_slice])
         self._request_serial += 1
         static_cache_key = self._request_serial
+        denoising_model_calls = 0
+        cache_candidates = 0
+        cache_threshold_passes = 0
+        cache_hits = 0
+        cache_forced_refreshes = 0
+        cache_consecutive_reuse = 0
+        cache_max_consecutive_reuse = 0
+        cache_video_deltas: list[float] = []
+        cache_audio_deltas: list[float] = []
+        cached_video_input: torch.Tensor | None = None
+        cached_audio_input: torch.Tensor | None = None
+        cached_video_velocity: torch.Tensor | None = None
+        cached_audio_velocity: torch.Tensor | None = None
 
         for step in range(len(video_sigmas) - 1):
             t_video = float(1.0 - video_sigmas[step])
@@ -481,28 +562,86 @@ class MiniMaxH3DenoisingStage(BaseStage):
             else:
                 x[0].index_copy_(0, target_img_pos, video_rows[video_target_slice])
                 audio_x[0].index_copy_(0, audio_pos[audio_update], audio_rows[audio_target_slice])
-            video_velocity, audio_velocity = self.transformer(
-                x=x,
-                audio_x=audio_x,
-                img_position_ids=img_position_ids,
-                unique_timesteps=unique_timesteps,
-                inverse_indices=inverse_indices,
-                update_mask=video_update,
-                update_audio_mask=audio_update,
-                prompt_embeds=prompt_embeds,
-                img_pos_info={"position_ids": img_pos},
-                audio_pos_info={"position_ids": audio_pos},
-                text_pos_info={"position_ids": text_pos},
-                img_pos_for_infer_output_info={"position_ids": target_img_pos},
-                packed_seq_params={"cu_seqlens_q": cu_seqlens},
-                block_token_tags=block_token_tags,
-                block_combined_indices=block_combined_indices,
-                local_embedding_layout=local_embedding_layout,
-                static_cache_key=static_cache_key,
-                sparse_step_index=step,
-                sol_prefix_tokens=sol_prefix_tokens,
-                skip_mask_out_condition=True,
+            cache_candidate = _dit_cache_step_is_candidate(step, denoising_steps, cache_config)
+            threshold_pass = False
+            if cache_candidate:
+                cache_candidates += 1
+            measure_cache_delta = bool(
+                cache_candidate
+                and cached_video_input is not None
+                and cached_audio_input is not None
+                and (cache_config.mode == "probe" or cache_config.threshold is not None)
             )
+            if measure_cache_delta:
+                cache_scores = torch.stack(
+                    (
+                        _relative_l1_delta(video_rows[video_target_slice], cached_video_input),
+                        _relative_l1_delta(audio_rows[audio_target_slice], cached_audio_input),
+                    )
+                )
+                if dist.is_available() and dist.is_initialized():
+                    dist.all_reduce(cache_scores, op=dist.ReduceOp.MAX)
+                video_delta, audio_delta = (float(value) for value in cache_scores.detach().cpu().tolist())
+                cache_video_deltas.append(video_delta)
+                cache_audio_deltas.append(audio_delta)
+                threshold_pass = (
+                    cache_config.threshold is None
+                    or max(video_delta, audio_delta) <= cache_config.threshold
+                )
+                cache_threshold_passes += int(threshold_pass)
+            elif cache_candidate and cache_config.threshold is None:
+                # Schedule-only reuse avoids a device synchronization and collective.
+                threshold_pass = True
+                cache_threshold_passes += 1
+
+            reuse_velocity = bool(
+                cache_config.mode == "velocity"
+                and cache_candidate
+                and threshold_pass
+                and cached_video_velocity is not None
+                and cached_audio_velocity is not None
+                and cache_consecutive_reuse < cache_config.max_consecutive_reuse
+            )
+            if reuse_velocity:
+                # The optimized scheduler may reuse velocity storage as scratch.
+                video_velocity = cached_video_velocity.clone()
+                audio_velocity = cached_audio_velocity.clone()
+                cache_hits += 1
+                cache_consecutive_reuse += 1
+                cache_max_consecutive_reuse = max(cache_max_consecutive_reuse, cache_consecutive_reuse)
+            else:
+                if cache_candidate:
+                    cache_forced_refreshes += 1
+                video_velocity, audio_velocity = self.transformer(
+                    x=x,
+                    audio_x=audio_x,
+                    img_position_ids=img_position_ids,
+                    unique_timesteps=unique_timesteps,
+                    inverse_indices=inverse_indices,
+                    update_mask=video_update,
+                    update_audio_mask=audio_update,
+                    prompt_embeds=prompt_embeds,
+                    img_pos_info={"position_ids": img_pos},
+                    audio_pos_info={"position_ids": audio_pos},
+                    text_pos_info={"position_ids": text_pos},
+                    img_pos_for_infer_output_info={"position_ids": target_img_pos},
+                    packed_seq_params={"cu_seqlens_q": cu_seqlens},
+                    block_token_tags=block_token_tags,
+                    block_combined_indices=block_combined_indices,
+                    local_embedding_layout=local_embedding_layout,
+                    static_cache_key=static_cache_key,
+                    sparse_step_index=step,
+                    sol_prefix_tokens=sol_prefix_tokens,
+                    skip_mask_out_condition=True,
+                )
+                denoising_model_calls += 1
+                cache_consecutive_reuse = 0
+                if cache_config.mode != "off":
+                    cached_video_input = video_rows[video_target_slice].detach().clone()
+                    cached_audio_input = audio_rows[audio_target_slice].detach().clone()
+                if cache_config.mode == "velocity":
+                    cached_video_velocity = video_velocity.detach().clone()
+                    cached_audio_velocity = audio_velocity.detach().clone()
             audio_target_velocity = audio_velocity[audio_target_slice]
             if optimized_update:
                 _minimax_h3_update_target_rows_(
@@ -564,6 +703,24 @@ class MiniMaxH3DenoisingStage(BaseStage):
             peak_reserved = 0
         runtime_metrics: dict[str, float | int] = {
             "denoising_seconds": time.perf_counter() - denoising_started,
+            "denoising_model_calls": int(denoising_model_calls),
+            "denoising_planned_model_calls": int(denoising_steps),
+            "dit_cache_mode": {"off": 0, "probe": 1, "velocity": 2}[cache_config.mode],
+            "dit_cache_candidates": int(cache_candidates),
+            "dit_cache_threshold_passes": int(cache_threshold_passes),
+            "dit_cache_hits": int(cache_hits),
+            "dit_cache_forced_refreshes": int(cache_forced_refreshes),
+            "dit_cache_hit_rate": float(cache_hits / denoising_steps) if denoising_steps else 0.0,
+            "dit_cache_candidate_hit_rate": float(cache_hits / cache_candidates) if cache_candidates else 0.0,
+            "dit_cache_max_consecutive_reuse": int(cache_max_consecutive_reuse),
+            "dit_cache_video_delta_mean": (
+                float(sum(cache_video_deltas) / len(cache_video_deltas)) if cache_video_deltas else 0.0
+            ),
+            "dit_cache_video_delta_max": float(max(cache_video_deltas)) if cache_video_deltas else 0.0,
+            "dit_cache_audio_delta_mean": (
+                float(sum(cache_audio_deltas) / len(cache_audio_deltas)) if cache_audio_deltas else 0.0
+            ),
+            "dit_cache_audio_delta_max": float(max(cache_audio_deltas)) if cache_audio_deltas else 0.0,
             "peak_allocated_bytes": peak_allocated,
             "peak_reserved_bytes": peak_reserved,
         }
@@ -584,6 +741,7 @@ class MiniMaxH3DenoisingStage(BaseStage):
         text: MiniMaxH3TextCondition | dict[str, torch.Tensor],
         conditions: list[MiniMaxH3PreparedCondition] | list[dict[str, Any]],
         num_inference_steps: int,
+        dit_cache_config: MiniMaxH3DiTCacheConfig | None = None,
     ) -> dict[str, Any]:
         """Keep the video latent on device while returning parent-consumed outputs separately."""
         result = self.denoise(
@@ -591,6 +749,7 @@ class MiniMaxH3DenoisingStage(BaseStage):
             text=text,
             conditions=conditions,
             num_inference_steps=num_inference_steps,
+            dit_cache_config=dit_cache_config,
             _transport_video=True,
         )
         return {
@@ -603,4 +762,9 @@ class MiniMaxH3DenoisingStage(BaseStage):
         }
 
 
-__all__ = ["MiniMaxH3DenoiseRemainder", "MiniMaxH3DenoiseResult", "MiniMaxH3DenoisingStage"]
+__all__ = [
+    "MiniMaxH3DenoiseRemainder",
+    "MiniMaxH3DenoiseResult",
+    "MiniMaxH3DenoisingStage",
+    "MiniMaxH3DiTCacheConfig",
+]

--- a/telefuser/pipelines/minimax_h3/denoising.py
+++ b/telefuser/pipelines/minimax_h3/denoising.py
@@ -59,9 +59,7 @@ class MiniMaxH3DiTCacheConfig:
         if normalized_mode == "conservative":
             normalized_mode = "velocity"
         if normalized_mode not in {"off", "probe", "velocity"}:
-            raise ValueError(
-                "MiniMax H3 DiT cache mode must be 'off', 'probe', 'velocity', or 'conservative'"
-            )
+            raise ValueError("MiniMax H3 DiT cache mode must be 'off', 'probe', 'velocity', or 'conservative'")
         object.__setattr__(self, "mode", normalized_mode)
         if not math.isfinite(self.start_ratio) or not 0.0 <= self.start_ratio < 1.0:
             raise ValueError("MiniMax H3 DiT cache start_ratio must be in [0, 1)")
@@ -585,8 +583,7 @@ class MiniMaxH3DenoisingStage(BaseStage):
                 cache_video_deltas.append(video_delta)
                 cache_audio_deltas.append(audio_delta)
                 threshold_pass = (
-                    cache_config.threshold is None
-                    or max(video_delta, audio_delta) <= cache_config.threshold
+                    cache_config.threshold is None or max(video_delta, audio_delta) <= cache_config.threshold
                 )
                 cache_threshold_passes += int(threshold_pass)
             elif cache_candidate and cache_config.threshold is None:

--- a/telefuser/pipelines/minimax_h3/pipeline.py
+++ b/telefuser/pipelines/minimax_h3/pipeline.py
@@ -22,7 +22,7 @@ from .data import (
     minimax_h3_validate_canonical_request,
     minimax_h3_validate_reference_media_facts,
 )
-from .denoising import MiniMaxH3DenoisingStage
+from .denoising import MiniMaxH3DenoisingStage, MiniMaxH3DiTCacheConfig
 from .material_io import (
     MiniMaxH3MaterialFacts,
     minimax_h3_localize_material,
@@ -49,12 +49,17 @@ class MiniMaxH3PipelineConfig:
     video_vae_config: ModelRuntimeConfig = field(default_factory=_fp32_runtime_config)
     audio_vae_config: ModelRuntimeConfig = field(default_factory=_fp32_runtime_config)
     num_inference_steps: int = 50
+    dit_cache_config: MiniMaxH3DiTCacheConfig = field(default_factory=MiniMaxH3DiTCacheConfig)
 
     def __post_init__(self) -> None:
         if not self.processor_path:
             raise ValueError("processor_path is required")
         if self.num_inference_steps < 2:
             raise ValueError("num_inference_steps must be at least 2")
+        if not isinstance(self.dit_cache_config, MiniMaxH3DiTCacheConfig):
+            raise TypeError("dit_cache_config must be a MiniMaxH3DiTCacheConfig")
+        if self.dit_cache_config.mode != "off" and self.dit_config.feature_cache_config.enabled:
+            raise ValueError("MiniMax H3 Conservative DiT cache cannot be combined with Feature Cache")
 
 
 @dataclass(frozen=True)
@@ -422,6 +427,7 @@ class MiniMaxH3Pipeline(BasePipeline):
                     text=text,
                     conditions=denoising_conditions,
                     num_inference_steps=steps,
+                    dit_cache_config=self.config.dit_cache_config,
                 )
                 video_latent = transported["video_latent"]
                 denoised = transported["remainder"]
@@ -432,6 +438,7 @@ class MiniMaxH3Pipeline(BasePipeline):
                     text=text,
                     conditions=denoising_conditions,
                     num_inference_steps=steps,
+                    dit_cache_config=self.config.dit_cache_config,
                 )
                 video_latent = denoised.video_latent
             video_device, video_decoding_seconds = self._timed_call(self.video_vae_stage.decode_video, video_latent)

--- a/tests/unit/kernel/test_minimax_h3_ulysses_kernels.py
+++ b/tests/unit/kernel/test_minimax_h3_ulysses_kernels.py
@@ -1,0 +1,76 @@
+import pytest
+import torch
+
+from telefuser.kernel.triton.ulysses_relayout import (
+    merge_ulysses_head_chunk,
+    pack_qkv_destination_major,
+    pack_qkv_qknorm_rope_destination_major,
+)
+from telefuser.ops.rotary import apply_qk_norm_rope_neox
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA Triton kernels")
+
+
+def test_fused_qknorm_rope_pack_is_bit_exact() -> None:
+    torch.manual_seed(0)
+    rows, heads, head_dim, world_size = 11, 4, 8, 2
+    qkv = torch.randn(rows, 3, heads, head_dim, device="cuda", dtype=torch.bfloat16)
+    q_weight = torch.randn(head_dim, device="cuda", dtype=torch.bfloat16)
+    k_weight = torch.randn(head_dim, device="cuda", dtype=torch.bfloat16)
+    angles = torch.randn(rows, 2, device="cuda")
+    cache = torch.cat((angles.cos(), angles.sin()), dim=-1)
+
+    reference_qkv = qkv.clone()
+    query, key, value = reference_qkv.unbind(dim=1)
+    query, key = apply_qk_norm_rope_neox(
+        query,
+        key,
+        q_weight,
+        k_weight,
+        cache,
+        eps=1e-5,
+    )
+    expected = pack_qkv_destination_major(query, key, value, world_size)
+    actual = pack_qkv_qknorm_rope_destination_major(
+        qkv,
+        q_weight,
+        k_weight,
+        cache,
+        world_size,
+        1e-5,
+    )
+
+    assert torch.equal(actual, expected)
+
+
+def test_merge_head_chunk_writes_valid_data_and_zero_tail() -> None:
+    torch.manual_seed(0)
+    world_size, valid_rows, output_rows = 2, 5, 8
+    batch, chunk_heads, total_local_heads, head_dim = 1, 1, 2, 8
+    received = torch.randn(
+        world_size,
+        valid_rows,
+        batch,
+        chunk_heads,
+        head_dim,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    output = torch.empty(
+        batch,
+        output_rows,
+        world_size,
+        total_local_heads,
+        head_dim,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+
+    actual = merge_ulysses_head_chunk(received, output, local_head_start=1, zero_tail=True)
+
+    expected = torch.empty_like(actual)
+    expected.fill_(float("nan"))
+    expected[:, :, :, 1].zero_()
+    for destination in range(world_size):
+        expected[0, :valid_rows, destination, 1].copy_(received[destination, :, 0, 0])
+    assert torch.equal(actual[:, :, :, 1], expected[:, :, :, 1])

--- a/tests/unit/models/test_minimax_h3_lossless_optimizations.py
+++ b/tests/unit/models/test_minimax_h3_lossless_optimizations.py
@@ -1,0 +1,138 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from telefuser.core.config import AttentionConfig, AttnImplType
+from telefuser.models.minimax_h3_dit import (
+    MiniMaxH3Attention,
+    MiniMaxH3DiTConfig,
+    _modulate,
+    _norm_modulate,
+    _rms_norm,
+)
+
+
+def _small_config() -> MiniMaxH3DiTConfig:
+    return MiniMaxH3DiTConfig(
+        hidden_size=32,
+        num_layers=2,
+        token_refiner_num_layers=1,
+        num_attention_heads=4,
+        attention_head_dim=8,
+        ffn_hidden_size=64,
+        latents_dim=2,
+        audio_latents_dim=2,
+        patch_size=(1, 2, 2),
+        text_dim=16,
+        timestep_input_dim=8,
+        time_embed_hidden_size=32,
+        time_embed_dim=16,
+        rope_inv_freq_len=1,
+    )
+
+
+def test_attention_config_validates_lossless_ulysses_options() -> None:
+    default = AttentionConfig.dense_attention(AttnImplType.FLASH_ATTN_4)
+    assert default.attention_chunks == 1
+    assert default.ulysses_sequence_mode == "padded"
+
+    optimized = AttentionConfig.dense_attention(
+        AttnImplType.FLASH_ATTN_4,
+        attention_chunks=2,
+        ulysses_sequence_mode="valid_only",
+    )
+    assert optimized.attention_chunks == 2
+    assert optimized.ulysses_sequence_mode == "valid_only"
+
+    with pytest.raises(ValueError, match="attention_chunks"):
+        AttentionConfig.dense_attention(AttnImplType.FLASH_ATTN_4, attention_chunks=3)
+    with pytest.raises(ValueError, match="ulysses_sequence_mode"):
+        AttentionConfig.dense_attention(AttnImplType.FLASH_ATTN_4, ulysses_sequence_mode="unknown")
+
+
+@pytest.mark.parametrize(
+    ("chunks", "sequence_mode", "expected_ranges", "pad_output", "zero_tail"),
+    [
+        (1, "padded", [(0, 2)], True, False),
+        (2, "valid_only", [(0, 1), (1, 1)], False, True),
+    ],
+)
+def test_fused_ulysses_path_obeys_public_configuration(
+    chunks: int,
+    sequence_mode: str,
+    expected_ranges: list[tuple[int, int]],
+    pad_output: bool,
+    zero_tail: bool,
+) -> None:
+    module = MiniMaxH3Attention(_small_config()).eval()
+    module.ulysses_group = MagicMock()
+    hidden = torch.randn(8, 32, dtype=torch.bfloat16)
+    rope = torch.randn(8, 2, dtype=torch.bfloat16)
+    scatter_ranges: list[tuple[int, int]] = []
+    attention_options: list[tuple[bool, bool]] = []
+    gather_options: list[bool] = []
+
+    def scatter(*_args: object, local_head_start: int, local_head_count: int, **_kwargs: object):
+        scatter_ranges.append((local_head_start, local_head_count))
+        tensor = torch.zeros(1, 8, local_head_count, 8, dtype=torch.bfloat16)
+        return lambda: (tensor, tensor, tensor)
+
+    def run_attention(query: torch.Tensor, *_args: object, **kwargs: object) -> torch.Tensor:
+        fixed_valid = bool(kwargs["fixed_valid"])
+        pad_fixed_valid_output = bool(kwargs["pad_fixed_valid_output"])
+        attention_options.append((fixed_valid, pad_fixed_valid_output))
+        return query if pad_fixed_valid_output else query[:, :5]
+
+    def gather(*_args: object, destination: torch.Tensor, zero_tail: bool, **_kwargs: object):
+        gather_options.append(zero_tail)
+
+        def wait() -> torch.Tensor:
+            destination.zero_()
+            return destination
+
+        return wait
+
+    config = AttentionConfig.dense_attention(
+        AttnImplType.FLASH_ATTN_4,
+        attention_chunks=chunks,
+        ulysses_sequence_mode=sequence_mode,
+    )
+    with (
+        patch("telefuser.models.minimax_h3_dit.dist.get_world_size", return_value=2),
+        patch("telefuser.models.minimax_h3_dit._can_run_fused_ulysses_attention", return_value=True),
+        patch(
+            "telefuser.models.minimax_h3_dit.ulysses_scatter_qkv_qknorm_rope_chunk_async",
+            side_effect=scatter,
+        ),
+        patch("telefuser.models.minimax_h3_dit.ulysses_gather_heads_chunk_async", side_effect=gather),
+        patch("telefuser.models.minimax_h3_dit.attention", side_effect=run_attention),
+    ):
+        output = module(
+            hidden,
+            sequence_lengths=[5, 3],
+            rope_cos_sin_cache=rope,
+            attention_config=config,
+            cu_seqlens=torch.tensor([0, 5, 8], dtype=torch.int32),
+        )
+
+    assert output.shape == hidden.shape
+    assert scatter_ranges == expected_ranges
+    assert attention_options == [(True, pad_output)] * chunks
+    assert gather_options == [zero_tail] * chunks
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA Triton kernels")
+def test_fused_norm_modulation_is_bit_exact() -> None:
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    norm = _rms_norm(32, 1e-5).to(device=device, dtype=torch.bfloat16)
+    hidden = torch.randn(17, 32, device=device, dtype=torch.bfloat16)
+    shift = torch.randn(3, 32, device=device, dtype=torch.bfloat16)
+    scale = torch.randn(3, 32, device=device, dtype=torch.bfloat16)
+    indices = torch.randint(0, 3, (17,), device=device)
+
+    expected = _modulate(norm(hidden.clone()), shift, scale, indices)
+    actual = _norm_modulate(norm, hidden.clone(), shift, scale, indices)
+
+    assert torch.equal(actual, expected)

--- a/tests/unit/ops/test_attention_backends.py
+++ b/tests/unit/ops/test_attention_backends.py
@@ -97,6 +97,30 @@ def test_flash_attn4_varlen_dispatch_reuses_cumulative_lengths() -> None:
     }
 
 
+@torch.no_grad()
+def test_flash_attn4_fixed_valid_can_return_only_live_tokens() -> None:
+    q = torch.randn(1, 5, 2, 4)
+    flash_attn4 = MagicMock(side_effect=lambda query, *_args, **_kwargs: (query.clone(), None))
+
+    with (
+        patch.object(attention_impl, "FLASH_ATTN_4_AVAILABLE", True),
+        patch.object(attention_impl, "flash_attn4", flash_attn4),
+    ):
+        output = attention_impl.attention(
+            q,
+            q,
+            q,
+            attn_impl=attention_impl.AttnImplType.FLASH_ATTN_4,
+            sequence_lengths=[3, 2],
+            fixed_valid=True,
+            pad_fixed_valid_output=False,
+        )
+
+    assert output.shape == (1, 3, 2, 4)
+    torch.testing.assert_close(output, q[:, :3])
+    assert flash_attn4.call_args.args[0].shape == (1, 3, 2, 4)
+
+
 def test_flash_attn4_packed_falls_back_to_sdpa_without_varlen_backend() -> None:
     q = torch.randn(1, 5, 2, 4)
 

--- a/tests/unit/pipelines/minimax_h3/test_examples.py
+++ b/tests/unit/pipelines/minimax_h3/test_examples.py
@@ -137,6 +137,12 @@ def test_standard_get_pipeline_forwards_parallel_runtime_options(monkeypatch: py
                 "attn_impl": AttnImplType.FLASH_ATTN_4,
                 "attention_chunks": 2,
                 "ulysses_sequence_mode": "valid_only",
+                "dit_cache_mode": "off",
+                "dit_cache_start_ratio": 0.2,
+                "dit_cache_end_ratio": 0.8,
+                "dit_cache_refresh_interval": 2,
+                "dit_cache_max_consecutive_reuse": 1,
+                "dit_cache_threshold": None,
                 "sol_fp8": False,
                 "sol_dense_steps": 10,
                 "sol_dense_layers": 2,
@@ -154,6 +160,22 @@ def test_standard_get_pipeline_forwards_parallel_runtime_options(monkeypatch: py
             },
         )
     ]
+
+
+def test_conservative_dit_cache_disables_default_online_adaln_collection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = []
+
+    def fake_loader(model_root: str, **kwargs: object) -> object:
+        calls.append((model_root, kwargs))
+        return object()
+
+    monkeypatch.setattr(fl2va_example, "load_minimax_h3_pipeline", fake_loader)
+    fl2va_example.get_pipeline(4, "/models/h3", dit_cache_mode="conservative")
+
+    assert calls[0][1]["dit_cache_mode"] == "conservative"
+    assert calls[0][1]["online_adaln_cache"] is False
 
 
 def test_cache_calibration_applies_validated_h3_profile(tmp_path: Path) -> None:

--- a/tests/unit/pipelines/minimax_h3/test_examples.py
+++ b/tests/unit/pipelines/minimax_h3/test_examples.py
@@ -135,6 +135,8 @@ def test_standard_get_pipeline_forwards_parallel_runtime_options(monkeypatch: py
                 "enable_fsdp": True,
                 "online_adaln_cache": True,
                 "attn_impl": AttnImplType.FLASH_ATTN_4,
+                "attention_chunks": 2,
+                "ulysses_sequence_mode": "valid_only",
                 "sol_fp8": False,
                 "sol_dense_steps": 10,
                 "sol_dense_layers": 2,

--- a/tests/unit/pipelines/minimax_h3/test_pipeline.py
+++ b/tests/unit/pipelines/minimax_h3/test_pipeline.py
@@ -12,7 +12,11 @@ from telefuser.core.config import (
 )
 from telefuser.core.module_manager import ModuleManager
 from telefuser.pipelines.minimax_h3.data import minimax_h3_validate_canonical_request
-from telefuser.pipelines.minimax_h3.denoising import MiniMaxH3DenoisingStage
+from telefuser.pipelines.minimax_h3.denoising import (
+    MiniMaxH3DenoisingStage,
+    MiniMaxH3DiTCacheConfig,
+    _dit_cache_step_is_candidate,
+)
 from telefuser.pipelines.minimax_h3.material_io import MiniMaxH3MaterialFacts
 from telefuser.pipelines.minimax_h3.pipeline import MiniMaxH3Pipeline, MiniMaxH3PipelineConfig
 from telefuser.pipelines.minimax_h3.resolved_plan import (
@@ -28,8 +32,10 @@ class _ZeroVelocityDiT(torch.nn.Module):
     def __init__(self) -> None:
         super().__init__()
         self.anchor = torch.nn.Parameter(torch.zeros(()))
+        self.calls = 0
 
     def forward(self, **kwargs):
+        self.calls += 1
         video_rows = kwargs["img_pos_for_infer_output_info"]["position_ids"].numel()
         audio_rows = kwargs["audio_pos_info"]["position_ids"].numel()
         device = self.anchor.device
@@ -194,6 +200,77 @@ def test_t2va_denoising_stage_runs_complete_packed_contract_on_cpu() -> None:
     assert result.runtime_metrics["peak_reserved_bytes"] == 0
     assert result.runtime_metrics["feature_cache_computed_steps"] == 1
     assert result.runtime_metrics["feature_cache_skipped_steps"] == 0
+
+
+def test_conservative_dit_cache_reuses_previous_velocity_on_schedule() -> None:
+    manager = ModuleManager(device="cpu")
+    transformer = _ZeroVelocityDiT()
+    manager.add_module(transformer, "minimax_h3_transformer")
+    stage = MiniMaxH3DenoisingStage(
+        manager,
+        ModelRuntimeConfig(device_type="cpu", torch_dtype=torch.float32),
+    )
+    canonical = minimax_h3_validate_canonical_request(
+        task="t2va",
+        prompt="move",
+        conditions=[],
+        target={"short_edge": 768, "aspect_ratio": "1:1", "duration_seconds": 4.0},
+        seed=0,
+    )
+    result = stage.denoise(
+        plan=minimax_h3_resolve_plan(canonical),
+        text=MiniMaxH3TextCondition(
+            hidden_states=torch.zeros(3, 5120, dtype=torch.bfloat16),
+            token_tags=torch.ones(3, dtype=torch.long),
+        ),
+        conditions=[],
+        num_inference_steps=6,
+        dit_cache_config=MiniMaxH3DiTCacheConfig(mode="conservative"),
+    )
+
+    assert transformer.calls == 4
+    assert result.runtime_metrics["denoising_planned_model_calls"] == 5
+    assert result.runtime_metrics["denoising_model_calls"] == 4
+    assert result.runtime_metrics["dit_cache_hits"] == 1
+    assert result.runtime_metrics["dit_cache_mode"] == 2
+
+
+def test_dit_cache_defaults_off_and_normalizes_conservative_alias() -> None:
+    off = MiniMaxH3DiTCacheConfig()
+    conservative = MiniMaxH3DiTCacheConfig(mode="CONSERVATIVE")
+
+    assert off.mode == "off"
+    assert conservative.mode == "velocity"
+    assert not any(_dit_cache_step_is_candidate(step, 49, off) for step in range(49))
+    assert [step for step in range(10) if _dit_cache_step_is_candidate(step, 10, conservative)] == [3, 5, 7]
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"mode": "unknown"}, "mode"),
+        ({"start_ratio": -0.1}, "start_ratio"),
+        ({"end_ratio": 1.1}, "end_ratio"),
+        ({"start_ratio": 0.8, "end_ratio": 0.8}, "smaller"),
+        ({"refresh_interval": 1}, "refresh_interval"),
+        ({"refresh_interval": 2.5}, "refresh_interval"),
+        ({"max_consecutive_reuse": 0}, "max_consecutive_reuse"),
+        ({"max_consecutive_reuse": 1.5}, "max_consecutive_reuse"),
+        ({"threshold": -0.1}, "threshold"),
+    ],
+)
+def test_dit_cache_rejects_invalid_configuration(kwargs: dict[str, object], match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        MiniMaxH3DiTCacheConfig(**kwargs)
+
+
+def test_pipeline_config_rejects_two_cross_step_caches() -> None:
+    with pytest.raises(ValueError, match="cannot be combined with Feature Cache"):
+        MiniMaxH3PipelineConfig(
+            processor_path="unused",
+            dit_config=ModelRuntimeConfig(feature_cache_config=FeatureCacheConfig(enabled=True)),
+            dit_cache_config=MiniMaxH3DiTCacheConfig(mode="conservative"),
+        )
 
 
 def test_denoising_rejects_corrupt_transported_token_tags() -> None:


### PR DESCRIPTION
This PR contains the Conservative DiT velocity cache, disabled by default, and depends on the lossless optimizations in PR #37.

> Please review and merge #37 first. Once #37 is merged, this PR will contain only the Conservative optimization relative to `main`.

# TeleFuser MiniMax-H3: Conservative DiT Velocity Cache

## 1. Summary

This implementation adds a Conservative DiT velocity cache on top of the five lossless optimizations from PR #37. The cache is disabled by default. Under a four-GPU setup with five prompt/seed pairs, the final results are:

| Configuration | Avg. wall time | Speedup vs. baseline | Avg. denoise time | DiT calls | Cache hits |
|---|---:|---:|---:|---:|---:|
| Baseline | 78.546 s | 0.000% | 75.737 s | 49 | 0 |
| Five lossless optimizations | 75.766 s | 3.539% | 72.934 s | 49 | 0 |
| Conservative only | 55.450 s | 29.404% | 52.612 s | 34 | 15 |
| All optimizations | 53.380 s | 32.040% | 50.601 s | 34 | 15 |

## 2. Lossless optimizations from PR #37

PR #37 provides the following five lossless optimizations:

- Overlap Ulysses communication with FlashAttention 4.
- Fuse Q/K RMSNorm, RoPE, and Ulysses packing.
- Add fixed-valid and valid-only attention modes.
- Fuse valid-only gather with zero-tail merge.
- Fuse RMSNorm with indexed AdaLN modulation.

These changes are described and validated in detail in PR #37.

## 3. Conservative DiT velocity cache

Added `MiniMaxH3DiTCacheConfig`:

```text
mode="off"
start_ratio=0.2
end_ratio=0.8
refresh_interval=2
max_consecutive_reuse=1
threshold=None
```

`conservative` is accepted as an alias for `velocity`. In the default validation schedule, caching is active only between 20% and 80% of the denoising process. A DiT refresh is forced every other step, and at most one consecutive step reuses the previous video/audio velocity.

When the cache is hit, the previous DiT-predicted video and audio velocities are reused and the current DiT invocation is skipped.

## 4. Per-case performance

| Case | Baseline (s) | Lossless (s) | Conservative only (s) | All optimizations (s) |
|---|---:|---:|---:|---:|
| P0/S0 | 78.426 | 75.745 | 55.347 | 53.503 |
| P0/S42 | 78.420 | 75.893 | 55.618 | 53.334 |
| P0/S1234 | 78.801 | 75.740 | 55.423 | 53.413 |
| P1/S0 | 78.612 | 75.706 | 55.400 | 53.366 |
| P1/S42 | 78.473 | 75.745 | 55.463 | 53.284 |

## 5. Quality verification

All quality comparisons use the baseline generated with the same prompt and seed, comparing the final video and audio MP4 outputs.

| Configuration | Exact MP4 SHA match | Video PSNR | Video SSIM | Audio cosine | Audio SNR | Audio RMSE |
|---|---:|---:|---:|---:|---:|---:|
| Five lossless optimizations | 5/5 | inf | 1.000000 | 1.000000 | inf | 0 |
| Conservative only | 0/5 | 35.860 dB | 0.964553 | 0.988936 | 18.811 dB | 0.015783 |
| All optimizations | 0/5 | 35.860 dB | 0.964553 | 0.988936 | 18.811 dB | 0.015783 |

Additional hash checks:

- `baseline == lossless`: 5/5.
- `lossy_only == all`: 5/5.

The lossless optimizations are bit-exact with the baseline at the final video and audio file level. The Conservative cache changes the denoising trajectory and final outputs, so it is a lossy optimization. The average PSNR, SSIM, and audio metrics show that the quality difference is limited under the tested settings.