### PR TITLE
Feat: Attention Smoothing to Improve Generation Quality

### DIFF
--- a/benchmarks/fp8_sol_attention_quality/README.md
+++ b/benchmarks/fp8_sol_attention_quality/README.md
@@ -1,0 +1,67 @@
+# MiniMax-H3 FP8 Sol Attention Quality
+
+Date: 2026-08-28
+
+## Scope
+
+- Model: `MiniMaxAI/MiniMax-H3`, FL2VA partition
+- Hardware: one NVIDIA H100 80 GB; no sequence or tensor parallelism
+- Request: T2VA, 1344x768, 4 seconds, 50 denoising steps, seed 0
+- Prompt: `Steam rises from the ramen while the family talks in the background.`
+- Sol policy: 10 dense steps, 2 dense layers, `tau=1.0`, exact threshold
+- FP8 profiles: tf-kernel W8A8 Linear plus post-RoPE E4M3 Q/K/V
+- Timing: one cold measured request per clean process; no warm-up
+
+The three FP8 runs differ only at the QKV quantization boundary. `K` subtracts
+the per-head sequence mean from K. `K+V+bias` also centers V, adds the V mean
+back to the attention output, and corrects the residual V mean after E4M3
+rounding. These are attention-equivalent transforms, not Linear SmoothQuant.
+
+## Results
+
+| Profile | Denoise (s) | Throughput (step/s) | Peak allocated (GiB) | Video cosine | Audio cosine | DINOv3 mean / min |
+|---|---:|---:|---:|---:|---:|---:|
+| BF16 Linear + FA4 | 212.474 | 0.2353 | 64.67 | 1.0000 | 1.0000 | 1.0000 / 1.0000 |
+| FP8 Sol, unsmoothed | 150.940 | 0.3313 | 37.11 | 0.8882 | 0.4220 | 0.8456 / 0.7367 |
+| FP8 Sol, K smoothing | 151.802 | 0.3294 | 37.11 | 0.8753 | 0.4045 | **0.8768** / 0.7935 |
+| FP8 Sol, K+V smoothing + V bias correction | 154.019 | 0.3246 | 37.11 | 0.8770 | **0.5094** | 0.8748 / **0.8011** |
+
+Pixel metrics compare all decoded uint8 frames and float32 audio samples against
+the matched BF16 output. DINOv3 metrics are corresponding-frame feature cosine
+over every fourth frame using
+`facebook/dinov3-vith16plus-pretrain-lvd1689m`. Pixel similarity is not
+monotonic with the attention-level error reduction because small numerical
+changes can move a diffusion trajectory while preserving its composition. The
+DINOv3 result and synchronized frame review capture that perceptual behavior:
+both smoothing modes improve corresponding-frame structure, while K+V also
+substantially improves the synchronized audio match and the worst video frame.
+
+The selected K+V profile has a 2.0% denoising cost versus unsmoothed FP8 Sol. It
+still improves throughput by 38.0% and lowers peak allocated memory by 42.6%
+versus the BF16 baseline.
+
+## Reproduction
+
+```bash
+CUDA_VISIBLE_DEVICES=0 python -m tools.validation.benchmark_minimax_h3_fp8_sol_sp \
+  --gpu-num 1 --profile baseline --duration 4 --steps 50 --no-warmup \
+  --output outputs/h3_bf16.mp4
+
+CUDA_VISIBLE_DEVICES=0 python -m tools.validation.benchmark_minimax_h3_fp8_sol_sp \
+  --gpu-num 1 --profile optimized --duration 4 --steps 50 --no-warmup \
+  --sol-fp8-smoothing none --no-sol-fp8-v-bias-correction \
+  --output outputs/h3_fp8_sol_unsmoothed.mp4
+
+CUDA_VISIBLE_DEVICES=0 python -m tools.validation.benchmark_minimax_h3_fp8_sol_sp \
+  --gpu-num 1 --profile optimized --duration 4 --steps 50 --no-warmup \
+  --sol-fp8-smoothing k --no-sol-fp8-v-bias-correction \
+  --output outputs/h3_fp8_sol_k.mp4
+
+CUDA_VISIBLE_DEVICES=0 python -m tools.validation.benchmark_minimax_h3_fp8_sol_sp \
+  --gpu-num 1 --profile optimized --duration 4 --steps 50 --no-warmup \
+  --sol-fp8-smoothing kv --sol-fp8-v-bias-correction \
+  --output outputs/h3_fp8_sol_kv_bias.mp4
+```
+
+The benchmark saves synchronized MP4, `.frames.npy`, `.audio.npy`, and metrics
+JSON artifacts. MP4 and NumPy artifacts remain local and are excluded from Git.

--- a/benchmarks/fp8_sol_attention_quality/README.md
+++ b/benchmarks/fp8_sol_attention_quality/README.md
@@ -10,7 +10,8 @@ Date: 2026-08-28
 - Prompt: `Steam rises from the ramen while the family talks in the background.`
 - Sol policy: 10 dense steps, 2 dense layers, `tau=1.0`, exact threshold
 - FP8 profiles: tf-kernel W8A8 Linear plus post-RoPE E4M3 Q/K/V
-- Timing: one cold measured request per clean process; no warm-up
+- Timing: cold measured requests in clean processes; no warm-up. The matched
+  unsmoothed and final fused profiles report the mean of two runs.
 
 The three FP8 runs differ only at the QKV quantization boundary. `K` subtracts
 the per-head sequence mean from K. `K+V+bias` also centers V, adds the V mean
@@ -22,9 +23,9 @@ rounding. These are attention-equivalent transforms, not Linear SmoothQuant.
 | Profile | Denoise (s) | Throughput (step/s) | Peak allocated (GiB) | Video cosine | Audio cosine | DINOv3 mean / min |
 |---|---:|---:|---:|---:|---:|---:|
 | BF16 Linear + FA4 | 212.474 | 0.2353 | 64.67 | 1.0000 | 1.0000 | 1.0000 / 1.0000 |
-| FP8 Sol, unsmoothed | 150.940 | 0.3313 | 37.11 | 0.8882 | 0.4220 | 0.8456 / 0.7367 |
+| FP8 Sol, unsmoothed | 150.776 | 0.3316 | 37.11 | 0.8882 | 0.4220 | 0.8456 / 0.7367 |
 | FP8 Sol, K smoothing | 151.802 | 0.3294 | 37.11 | 0.8753 | 0.4045 | **0.8768** / 0.7935 |
-| FP8 Sol, K+V smoothing + V bias correction | 154.019 | 0.3246 | 37.11 | 0.8770 | **0.5094** | 0.8748 / **0.8011** |
+| FP8 Sol, fused K+V smoothing + V bias correction | 152.239 | 0.3284 | 37.11 | 0.8770 | **0.5094** | 0.8748 / **0.8011** |
 
 Pixel metrics compare all decoded uint8 frames and float32 audio samples against
 the matched BF16 output. DINOv3 metrics are corresponding-frame feature cosine
@@ -36,9 +37,38 @@ DINOv3 result and synchronized frame review capture that perceptual behavior:
 both smoothing modes improve corresponding-frame structure, while K+V also
 substantially improves the synchronized audio match and the worst video frame.
 
-The selected K+V profile has a 2.0% denoising cost versus unsmoothed FP8 Sol. It
-still improves throughput by 38.0% and lowers peak allocated memory by 42.6%
-versus the BF16 baseline.
+The final exact K+V profile has a 0.97% mean denoising cost and 0.96% mean
+throughput cost versus unsmoothed FP8 Sol. The two-run denoising ranges are
+150.612-150.940 seconds for unsmoothed and 152.111-152.367 seconds for fused
+K+V. It still improves throughput by 39.6% and lowers peak allocated memory by
+42.6% versus the BF16 baseline.
+
+## Fusion results
+
+The optimized path combines K and V sequence statistics into one Triton
+reduction and merges the BF16 dense prefix with the corrected sparse suffix in
+one output pass. It preserves the original four-warp reduction order. At the
+actual H3 attention shape `(1, 32640, 40, 128)`, 100-repetition H100 medians are:
+
+| Boundary operation | Before fusion (ms) | After fusion (ms) | Change |
+|---|---:|---:|---:|
+| Exact K/V sequence statistics | 0.9836 | 0.5950 | -39.5% |
+| Smoothed QKV quantization and correction statistics | 1.8964 | 1.5081 | -20.5% |
+| Output correction and dense-prefix merge | 0.6317 | 0.4000 | -36.7% |
+| Combined measured boundary | 2.5281 | 1.9080 | **-24.5%** |
+
+The fused output is bitwise identical to the pre-fusion exact implementation:
+both 50-step fused runs have the same frame and audio SHA256 as the original
+K+V run. Consequently, all pixel, DINOv3, audio, and visual-review results above
+remain unchanged. Peak allocated memory also remains 37.11 GiB; fusion adds no
+large partial-statistics buffer.
+
+Several faster-looking approximations were rejected. A two-warp reduction was
+faster but changed long-sequence FP32 summation by up to `3.7e-9`, which changed
+the diffusion output. Sampling K/V centers damaged Sol routing quality, and a
+block-partial V-bias fusion was slower than directly scanning the compact FP8 V
+tensor. The remaining approximately 1% overhead is the cost of exact global
+statistics; it was not removed by sacrificing output fidelity.
 
 ## Reproduction
 

--- a/benchmarks/fp8_sol_attention_quality/README.md
+++ b/benchmarks/fp8_sol_attention_quality/README.md
@@ -107,7 +107,6 @@ CUDA_VISIBLE_DEVICES=0 python -m tools.validation.benchmark_minimax_h3_fp8_sol_s
 
 CUDA_VISIBLE_DEVICES=0 python -m tools.validation.benchmark_minimax_h3_fp8_sol_sp \
   --gpu-num 1 --profile optimized --duration 4 --steps 50 --no-warmup \
-  --sol-fp8-smoothing kv --sol-fp8-v-bias-correction \
   --output outputs/h3_fp8_sol_kv_bias.mp4
 ```
 

--- a/benchmarks/fp8_sol_attention_quality/README.md
+++ b/benchmarks/fp8_sol_attention_quality/README.md
@@ -1,74 +1,97 @@
 # MiniMax-H3 FP8 Sol Attention Quality
 
-Date: 2026-08-28
+Date: 2026-09-08
 
 ## Scope
 
 - Model: `MiniMaxAI/MiniMax-H3`, FL2VA partition
 - Hardware: one NVIDIA H100 80 GB; no sequence or tensor parallelism
-- Request: T2VA, 1344x768, 4 seconds, 50 denoising steps, seed 0
+- Request: T2VA, 1344x768, 4 seconds, 107 decoded frames, 50 denoising steps, seed 0
 - Prompt: `Steam rises from the ramen while the family talks in the background.`
 - Sol policy: 10 dense steps, 2 dense layers, `tau=1.0`, exact threshold
-- FP8 profiles: tf-kernel W8A8 Linear plus post-RoPE E4M3 Q/K/V
-- Timing: cold measured requests in clean processes; no warm-up. The matched
-  unsmoothed and final fused profiles report the mean of two runs.
+- FP8 profile: tf-kernel W8A8 Linear plus post-RoPE E4M3 Q/K/V
+- Timing: cold measured requests in clean processes with no warm-up. FP8 values are means of two runs; the BF16
+  reference is one run.
 
-The three FP8 runs differ only at the QKV quantization boundary. `K` subtracts
-the per-head sequence mean from K. `K+V+bias` also centers V, adds the V mean
-back to the attention output, and corrects the residual V mean after E4M3
+The two FP8 profiles differ only at the QKV quantization boundary. The final profile subtracts per-head sequence
+means from K and V, adds the V mean back to the attention output, and corrects the residual V mean after E4M3
 rounding. These are attention-equivalent transforms, not Linear SmoothQuant.
 
-## Results
+## End-to-end results
 
-| Profile | Denoise (s) | Throughput (step/s) | Peak allocated (GiB) | Video cosine | Audio cosine | DINOv3 mean / min |
-|---|---:|---:|---:|---:|---:|---:|
-| BF16 Linear + FA4 | 212.474 | 0.2353 | 64.67 | 1.0000 | 1.0000 | 1.0000 / 1.0000 |
-| FP8 Sol, unsmoothed | 150.776 | 0.3316 | 37.11 | 0.8882 | 0.4220 | 0.8456 / 0.7367 |
-| FP8 Sol, K smoothing | 151.802 | 0.3294 | 37.11 | 0.8753 | 0.4045 | **0.8768** / 0.7935 |
-| FP8 Sol, fused K+V smoothing + V bias correction | 152.239 | 0.3284 | 37.11 | 0.8770 | **0.5094** | 0.8748 / **0.8011** |
+| Profile | Denoise mean / range (s) | Throughput (step/s) | Peak allocated (GiB) |
+|---|---:|---:|---:|
+| BF16 Linear + FA4 | 211.442 | 0.23647 | 64.67 |
+| FP8 Sol, unsmoothed | 148.446 / 148.372-148.520 | **0.33682** | 37.11 |
+| FP8 Sol, fused KV smoothing + V bias correction | 151.651 / 151.328-151.974 | 0.32971 | **37.11** |
 
-Pixel metrics compare all decoded uint8 frames and float32 audio samples against
-the matched BF16 output. DINOv3 metrics are corresponding-frame feature cosine
-over every fourth frame using
-`facebook/dinov3-vith16plus-pretrain-lvd1689m`. Pixel similarity is not
-monotonic with the attention-level error reduction because small numerical
-changes can move a diffusion trajectory while preserving its composition. The
-DINOv3 result and synchronized frame review capture that perceptual behavior:
-both smoothing modes improve corresponding-frame structure, while K+V also
-substantially improves the synchronized audio match and the worst video frame.
+The final profile is 39.4% faster and uses 42.6% less peak allocated memory than the matched BF16 reference. Against
+unsmoothed FP8 Sol, smoothing adds 2.16% mean denoising time and reduces mean throughput by 2.11%; peak allocated
+memory is unchanged. The duplicate FP8 runs produced identical frame and audio SHA256 hashes within each profile.
 
-The final exact K+V profile has a 0.97% mean denoising cost and 0.96% mean
-throughput cost versus unsmoothed FP8 Sol. The two-run denoising ranges are
-150.612-150.940 seconds for unsmoothed and 152.111-152.367 seconds for fused
-K+V. It still improves throughput by 39.6% and lowers peak allocated memory by
-42.6% versus the BF16 baseline.
+## Attention-boundary error
+
+Real post-QK-norm, post-RoPE Q/K/V were captured from the first active Sol layer. The live tensor shape was
+`(1, 32626, 56, 128)` within a 32640-token padded request. The measurement used heads 0-3 over the complete live K/V
+context. Dense-attention output error used 64 evenly spaced query positions and FP32 math against the original BF16
+Q/K/V. This isolates the quantization boundary; it is not a full-generation metric.
+
+| Tensor boundary | Unsmoothed MSE | Smoothed MSE | MSE reduction |
+|---|---:|---:|---:|
+| K at the quantizer input distribution | 9.380e-4 | 7.349e-4 | **21.65%** |
+| V at the quantizer input distribution | 1.647e-2 | 1.611e-2 | 2.16% |
+| Reconstructed V | 1.647e-2 | 1.611e-2 | 2.17% |
+| Per-head/channel reconstructed V mean bias | 1.044e-6 | 2.561e-14 | **>99.99999%** |
+| Dense attention output | 7.034e-4 | 6.459e-4 | **8.18%** |
+
+For the dense attention output, smoothing also improved cosine similarity from 0.999403 to 0.999452, relative L2
+error from 0.03455 to 0.03311, and SQNR from 29.23 to 29.60 dB. Q is intentionally unchanged by smoothing and had
+identical quantization output in both profiles.
+
+## Generated media comparison
+
+The following metrics compare decoded outputs with the same-seed BF16 trajectory. They measure numerical trajectory
+similarity, not absolute perceptual quality: a small attention perturbation can select a different valid diffusion
+trajectory.
+
+| Profile | Frame cosine | PSNR (dB) | SSIM mean / min |
+|---|---:|---:|---:|
+| FP8 Sol, unsmoothed | 0.87488 | 14.695 | 0.5464 / 0.5151 |
+| FP8 Sol, KV smoothing + V correction | **0.87729** | **14.800** | **0.5659 / 0.5382** |
+
+SSIM was evaluated on every fourth frame (27 synchronized frames). All-frame cosine and PSNR use all 107 decoded
+uint8 frames.
+
+| Profile | Waveform cosine | Waveform MSE | SI-SDR (dB) | Spectral convergence | Log-spectral distance (dB) |
+|---|---:|---:|---:|---:|---:|
+| FP8 Sol, unsmoothed | **0.55217** | **9.842e-5** | **-3.579** | **0.6301** | **12.484** |
+| FP8 Sol, KV smoothing + V correction | 0.53450 | 1.026e-4 | -3.980 | 0.6388 | 12.522 |
+
+Both FP8 videos are coherent and preserve the prompt's ramen-dining composition without corrupted frames. Smoothing
+improves every reported video trajectory metric in this seed, while the unsmoothed output is closer to BF16 on the
+reported audio trajectory metrics. This single-seed media comparison therefore does not establish a universal audio
+quality ranking; the attention-boundary metrics directly measure the error targeted by the implementation.
 
 ## Fusion results
 
-The optimized path combines K and V sequence statistics into one Triton
-reduction and merges the BF16 dense prefix with the corrected sparse suffix in
-one output pass. It preserves the original four-warp reduction order. At the
-actual H3 attention shape `(1, 32640, 40, 128)`, 100-repetition H100 medians are:
+The optimized path combines K and V sequence statistics into one Triton reduction and merges the BF16 dense prefix
+with the corrected sparse suffix in one output pass. At the current H3 live shape `(1, 32626, 56, 128)`, H100
+100-repetition means are:
 
 | Boundary operation | Before fusion (ms) | After fusion (ms) | Change |
 |---|---:|---:|---:|
-| Exact K/V sequence statistics | 0.9836 | 0.5950 | -39.5% |
-| Smoothed QKV quantization and correction statistics | 1.8964 | 1.5081 | -20.5% |
-| Output correction and dense-prefix merge | 0.6317 | 0.4000 | -36.7% |
-| Combined measured boundary | 2.5281 | 1.9080 | **-24.5%** |
+| Exact K/V sequence statistics | 1.0097 | 0.5319 | -47.3% |
+| Smoothed QKV quantization and correction statistics | 2.5795 | 2.1054 | -18.4% |
+| Output correction and dense-prefix merge | 0.8776 | 0.5540 | -36.9% |
+| Combined quantization/correction and output boundary | 3.4571 | 2.6594 | **-23.1%** |
 
-The fused output is bitwise identical to the pre-fusion exact implementation:
-both 50-step fused runs have the same frame and audio SHA256 as the original
-K+V run. Consequently, all pixel, DINOv3, audio, and visual-review results above
-remain unchanged. Peak allocated memory also remains 37.11 GiB; fusion adds no
-large partial-statistics buffer.
+The GPU tests verify the fused K/V statistics, quantized tensors, correction, and fused prefix merge are bitwise
+identical to their unfused exact implementations. Fusion adds no large partial-statistics buffer.
 
-Several faster-looking approximations were rejected. A two-warp reduction was
-faster but changed long-sequence FP32 summation by up to `3.7e-9`, which changed
-the diffusion output. Sampling K/V centers damaged Sol routing quality, and a
-block-partial V-bias fusion was slower than directly scanning the compact FP8 V
-tensor. The remaining approximately 1% overhead is the cost of exact global
-statistics; it was not removed by sacrificing output fidelity.
+Several faster-looking approximations were rejected. A two-warp reduction changed long-sequence FP32 summation,
+sampling K/V centers damaged Sol routing quality, and a block-partial V-bias fusion was slower than directly scanning
+the compact FP8 V tensor. The remaining end-to-end cost is the exact global-statistics work; it was not removed by
+sacrificing the target error reduction.
 
 ## Reproduction
 
@@ -84,14 +107,9 @@ CUDA_VISIBLE_DEVICES=0 python -m tools.validation.benchmark_minimax_h3_fp8_sol_s
 
 CUDA_VISIBLE_DEVICES=0 python -m tools.validation.benchmark_minimax_h3_fp8_sol_sp \
   --gpu-num 1 --profile optimized --duration 4 --steps 50 --no-warmup \
-  --sol-fp8-smoothing k --no-sol-fp8-v-bias-correction \
-  --output outputs/h3_fp8_sol_k.mp4
-
-CUDA_VISIBLE_DEVICES=0 python -m tools.validation.benchmark_minimax_h3_fp8_sol_sp \
-  --gpu-num 1 --profile optimized --duration 4 --steps 50 --no-warmup \
   --sol-fp8-smoothing kv --sol-fp8-v-bias-correction \
   --output outputs/h3_fp8_sol_kv_bias.mp4
 ```
 
-The benchmark saves synchronized MP4, `.frames.npy`, `.audio.npy`, and metrics
-JSON artifacts. MP4 and NumPy artifacts remain local and are excluded from Git.
+The benchmark saves synchronized MP4, `.frames.npy`, `.audio.npy`, and metrics JSON artifacts. MP4 and NumPy
+artifacts remain local and are excluded from Git.

--- a/docs/en/blog/fp8_sol_attention.md
+++ b/docs/en/blog/fp8_sol_attention.md
@@ -224,6 +224,19 @@ MiniMax-H3 has a packed multimodal sequence, so it needs two additional protecti
 prefix is registered as an exact KV sink, and prefix queries are recomputed with BF16 dense attention. The first ten
 steps and first two DiT layers also use matched packed FlashAttention-4. Token-refiner attention remains dense.
 
+MiniMax-H3 FP8 Sol also defaults to attention-specific sequence-mean smoothing. This is not Linear SmoothQuant and
+does not migrate scale between a Linear activation and its weights. For one head, TeleFuser applies
+
+$$K' = K - \operatorname{mean}_{T}(K), \qquad V' = V - \operatorname{mean}_{T}(V).$$
+
+The K shift adds the same scalar to every logit in a query row, so softmax is unchanged. Since every softmax row sums
+to one, the original result is recovered by adding `mean_T(V)` to the attention output. TeleFuser computes both means
+in FP32, fuses their subtraction into SM90 E4M3 preparation, and corrects the residual mean bias measured after V is
+rounded to E4M3. `sol_fp8_smoothing=none|k|kv` controls the two equivalent transforms, while
+`sol_fp8_v_bias_correction` controls the post-quantization V correction for ablation.
+The matched single-H100 quality and performance ablation is recorded in
+[`benchmarks/fp8_sol_attention_quality`](../../../benchmarks/fp8_sol_attention_quality/README.md).
+
 Unsupported shapes, dtypes, devices, or runtime kernel failures retain the public attention fallback. FP8 operands
 are dequantized before the BF16 fallback. Pure Ulysses sequence parallelism is supported: its all-to-all first
 produces full-sequence, local-head Q/K/V, then each rank computes FP8 scales and runs Sol independently. Ring and

--- a/docs/en/blog/fp8_sol_attention.md
+++ b/docs/en/blog/fp8_sol_attention.md
@@ -234,6 +234,10 @@ to one, the original result is recovered by adding `mean_T(V)` to the attention 
 in FP32, fuses their subtraction into SM90 E4M3 preparation, and corrects the residual mean bias measured after V is
 rounded to E4M3. `sol_fp8_smoothing=none|k|kv` controls the two equivalent transforms, while
 `sol_fp8_v_bias_correction` controls the post-quantization V correction for ablation.
+The exact K/V statistics share one fused reduction, and a second Triton kernel merges the BF16 dense prefix with the
+corrected sparse suffix in one output pass. At the H3 attention shape this reduces the measured smoothing boundary by
+24.5% while remaining bitwise identical to the unfused implementation. Two matched 50-step runs leave a 0.96%
+throughput difference versus unsmoothed FP8 Sol, with unchanged 37.11 GiB peak allocated memory.
 The matched single-H100 quality and performance ablation is recorded in
 [`benchmarks/fp8_sol_attention_quality`](../../../benchmarks/fp8_sol_attention_quality/README.md).
 
@@ -341,13 +345,16 @@ python examples/wan_video/wan21_1_3b_text_to_video_optimized_h100.py \
   128. BF16 Sol has broader architecture fallbacks, but the performance result does not transfer to them.
 - MiniMax-H3 online `tf-kernel` FP8 Linear quantization is currently single-GPU only. Its TP/FSDP loading contract
   remains BF16.
-- QKV quantization and centroid preprocessing are separate kernels. Further fusion may reduce launch and memory-traffic overhead, but would increase specialization and register pressure.
+- Exact sequence statistics still precede QKV quantization. Fusing the K/V reduction and output merge reduces the
+  boundary overhead, but the remaining global reduction leaves about a 1% measured throughput difference versus
+  unsmoothed FP8 Sol. Sampled statistics were rejected because they changed Sol routing quality.
 - CuTe compilation is shape- and dtype-specific. Cold-start latency includes compilation; persistent services should
   evaluate warm steady state separately.
 - The best FP8 layer range is model- and checkpoint-dependent. An all-layer setting should not be treated as the
   default quality/performance point.
-- Peak allocated memory is a CUDA allocator metric, not total process or device memory. The experiments report one
-  run per configuration and do not establish variance bounds.
+- Peak allocated memory is a CUDA allocator metric, not total process or device memory. The matched unsmoothed and
+  final fused profiles report two runs; the other ablation points report one run, so these results do not establish
+  broad variance bounds.
 
 ## Related Work
 

--- a/docs/en/blog/fp8_sol_attention.md
+++ b/docs/en/blog/fp8_sol_attention.md
@@ -235,9 +235,9 @@ in FP32, fuses their subtraction into SM90 E4M3 preparation, and corrects the re
 rounded to E4M3. `sol_fp8_smoothing=none|k|kv` controls the two equivalent transforms, while
 `sol_fp8_v_bias_correction` controls the post-quantization V correction for ablation.
 The exact K/V statistics share one fused reduction, and a second Triton kernel merges the BF16 dense prefix with the
-corrected sparse suffix in one output pass. At the H3 attention shape this reduces the measured smoothing boundary by
-24.5% while remaining bitwise identical to the unfused implementation. Two matched 50-step runs leave a 0.96%
-throughput difference versus unsmoothed FP8 Sol, with unchanged 37.11 GiB peak allocated memory.
+corrected sparse suffix in one output pass. At the current H3 live shape `(1, 32626, 56, 128)`, this reduces the
+measured smoothing boundary by 23.1% while remaining bitwise identical to the unfused implementation. Two matched
+50-step runs show a 2.11% throughput cost versus unsmoothed FP8 Sol, with unchanged 37.11 GiB peak allocated memory.
 The matched single-H100 quality and performance ablation is recorded in
 [`benchmarks/fp8_sol_attention_quality`](https://github.com/Tele-AI/TeleFuser/tree/main/benchmarks/fp8_sol_attention_quality#readme).
 

--- a/docs/en/blog/fp8_sol_attention.md
+++ b/docs/en/blog/fp8_sol_attention.md
@@ -239,7 +239,7 @@ corrected sparse suffix in one output pass. At the H3 attention shape this reduc
 24.5% while remaining bitwise identical to the unfused implementation. Two matched 50-step runs leave a 0.96%
 throughput difference versus unsmoothed FP8 Sol, with unchanged 37.11 GiB peak allocated memory.
 The matched single-H100 quality and performance ablation is recorded in
-[`benchmarks/fp8_sol_attention_quality`](../../../benchmarks/fp8_sol_attention_quality/README.md).
+[`benchmarks/fp8_sol_attention_quality`](https://github.com/Tele-AI/TeleFuser/tree/main/benchmarks/fp8_sol_attention_quality#readme).
 
 Unsupported shapes, dtypes, devices, or runtime kernel failures retain the public attention fallback. FP8 operands
 are dequantized before the BF16 fallback. Pure Ulysses sequence parallelism is supported: its all-to-all first

--- a/docs/zh/blog/fp8_sol_attention.md
+++ b/docs/zh/blog/fp8_sol_attention.md
@@ -226,6 +226,10 @@ K 平移对同一 query row 的每个 logit 增加相同常数，因此 softmax 
 attention output 加回 `mean_T(V)` 即恢复原始结果。TeleFuser 使用 FP32 统计均值，把中心化融合进 SM90
 E4M3 preparation，并补偿 V 舍入到 E4M3 后实测到的残余均值偏差。`sol_fp8_smoothing=none|k|kv` 用于
 分别消融两个等价变换，`sol_fp8_v_bias_correction` 控制量化后 V 偏差补偿。
+exact K/V 统计共享一个 fused reduction，另一个 Triton kernel 在一次写出中合并 BF16 dense prefix 与完成
+correction 的 sparse suffix。在 H3 attention shape 上，这将 smoothing boundary 耗时降低 24.5%，并与融合前
+实现保持 bitwise 一致。两轮匹配的 50-step 实验中，相比 unsmoothed FP8 Sol 的吞吐差为 0.96%，peak
+allocated 显存均为 37.11 GiB。
 匹配的单卡 H100 画质与性能消融记录在
 [`benchmarks/fp8_sol_attention_quality`](../../../benchmarks/fp8_sol_attention_quality/README.md)。
 
@@ -327,12 +331,12 @@ python examples/wan_video/wan21_1_3b_text_to_video_optimized_h100.py \
 - 已验证的 FP8 attention mainloop 面向 SM90、noncausal self-attention、相同 Q/K/V shape 和 128 维 head。
   BF16 Sol 有更广的 architecture fallback，但本文性能数据不能直接迁移到这些路径。
 - MiniMax-H3 在线 `tf-kernel` FP8 Linear 目前只支持单 GPU；其 TP/FSDP loading contract 仍为 BF16。
-- QKV quantization 与 centroid preprocessing 是独立 kernel。进一步融合可能减少 launch 与访存开销，
-  但也会提高 specialization 数量和 register pressure。
+- exact sequence statistics 仍必须先于 QKV quantization。融合 K/V reduction 与 output merge 后，剩余的
+  全局 reduction 使吞吐相比 unsmoothed FP8 Sol 仍约低 1%；采样统计会改变 Sol routing 质量，因此未采用。
 - CuTe 编译与 shape、dtype 绑定。冷启动结果包含编译，常驻服务还应单独评估 warm steady state。
 - 最佳 FP8 layer range 依赖模型与 checkpoint，不能把全层 FP8 当作默认质量/性能点。
-- Peak allocated 是 CUDA allocator 指标，不是进程或整张 GPU 的总显存。每个配置只有一次测量，尚未给出
-  方差范围。
+- Peak allocated 是 CUDA allocator 指标，不是进程或整张 GPU 的总显存。匹配的 unsmoothed 与最终 fused
+  profile 各测了两轮，其他消融点各测一轮，因此这些结果尚不能建立完整的方差范围。
 
 ## 相关工作
 

--- a/docs/zh/blog/fp8_sol_attention.md
+++ b/docs/zh/blog/fp8_sol_attention.md
@@ -217,6 +217,18 @@ MiniMax-H3 使用 packed multimodal sequence，因此增加了两项保护：完
 KV sink，prefix query 使用 BF16 dense attention 重新计算。前十个 step、前两个 DiT layer 使用匹配的
 packed FlashAttention-4，token refiner 也始终保持 dense。
 
+MiniMax-H3 FP8 Sol 还默认使用 attention sequence-mean smoothing。它不是 Linear SmoothQuant，不会在
+Linear activation 与权重之间迁移 scale。对每个 attention head，TeleFuser 执行
+
+$$K' = K - \operatorname{mean}_{T}(K), \qquad V' = V - \operatorname{mean}_{T}(V).$$
+
+K 平移对同一 query row 的每个 logit 增加相同常数，因此 softmax 不变；softmax 每行权重和为 1，所以在
+attention output 加回 `mean_T(V)` 即恢复原始结果。TeleFuser 使用 FP32 统计均值，把中心化融合进 SM90
+E4M3 preparation，并补偿 V 舍入到 E4M3 后实测到的残余均值偏差。`sol_fp8_smoothing=none|k|kv` 用于
+分别消融两个等价变换，`sol_fp8_v_bias_correction` 控制量化后 V 偏差补偿。
+匹配的单卡 H100 画质与性能消融记录在
+[`benchmarks/fp8_sol_attention_quality`](../../../benchmarks/fp8_sol_attention_quality/README.md)。
+
 不支持的 shape、dtype、device 或 kernel runtime failure 会保留公共 attention fallback。FP8 operand 会先
 反量化再进入 BF16 fallback。纯 Ulysses sequence parallel 已支持：all-to-all 先得到完整 sequence、局部
 head 的 Q/K/V，每个 rank 再独立计算 FP8 scale 并运行 Sol。Ring 以及 Ulysses-ring 组合仍走 dense，因为

--- a/docs/zh/blog/fp8_sol_attention.md
+++ b/docs/zh/blog/fp8_sol_attention.md
@@ -231,7 +231,7 @@ correction 的 sparse suffix。在 H3 attention shape 上，这将 smoothing bou
 实现保持 bitwise 一致。两轮匹配的 50-step 实验中，相比 unsmoothed FP8 Sol 的吞吐差为 0.96%，peak
 allocated 显存均为 37.11 GiB。
 匹配的单卡 H100 画质与性能消融记录在
-[`benchmarks/fp8_sol_attention_quality`](../../../benchmarks/fp8_sol_attention_quality/README.md)。
+[`benchmarks/fp8_sol_attention_quality`](https://github.com/Tele-AI/TeleFuser/tree/main/benchmarks/fp8_sol_attention_quality#readme)。
 
 不支持的 shape、dtype、device 或 kernel runtime failure 会保留公共 attention fallback。FP8 operand 会先
 反量化再进入 BF16 fallback。纯 Ulysses sequence parallel 已支持：all-to-all 先得到完整 sequence、局部

--- a/docs/zh/blog/fp8_sol_attention.md
+++ b/docs/zh/blog/fp8_sol_attention.md
@@ -227,9 +227,9 @@ attention output 加回 `mean_T(V)` 即恢复原始结果。TeleFuser 使用 FP3
 E4M3 preparation，并补偿 V 舍入到 E4M3 后实测到的残余均值偏差。`sol_fp8_smoothing=none|k|kv` 用于
 分别消融两个等价变换，`sol_fp8_v_bias_correction` 控制量化后 V 偏差补偿。
 exact K/V 统计共享一个 fused reduction，另一个 Triton kernel 在一次写出中合并 BF16 dense prefix 与完成
-correction 的 sparse suffix。在 H3 attention shape 上，这将 smoothing boundary 耗时降低 24.5%，并与融合前
-实现保持 bitwise 一致。两轮匹配的 50-step 实验中，相比 unsmoothed FP8 Sol 的吞吐差为 0.96%，peak
-allocated 显存均为 37.11 GiB。
+correction 的 sparse suffix。在当前 H3 live shape `(1, 32626, 56, 128)` 上，这将 smoothing boundary 耗时降低
+23.1%，并与融合前实现保持 bitwise 一致。两轮匹配的 50-step 实验中，相比 unsmoothed FP8 Sol 的吞吐开销
+为 2.11%，peak allocated 显存均为 37.11 GiB。
 匹配的单卡 H100 画质与性能消融记录在
 [`benchmarks/fp8_sol_attention_quality`](https://github.com/Tele-AI/TeleFuser/tree/main/benchmarks/fp8_sol_attention_quality#readme)。
 

--- a/examples/minimax_h3/README.md
+++ b/examples/minimax_h3/README.md
@@ -421,7 +421,9 @@ the first 10 denoising steps and first 2 DiT layers remain dense, the full condi
 prefix queries are recomputed with BF16 dense attention. Adding `--sol-fp8` quantizes post-RoPE Q/K/V in active sparse
 layers and dispatches the SM90 CuTe FP8 Sol mainloop. The MiniMax-H3 quality profile also centers K and V over the live
 sequence before E4M3 conversion, adds the V mean back after attention, and corrects the residual V mean bias caused by
-E4M3 rounding. These are attention-equivalent transforms rather than Linear SmoothQuant.
+E4M3 rounding. These are attention-equivalent transforms rather than Linear SmoothQuant. K/V statistics use one exact
+fused reduction, and dense-prefix replacement is fused with the sparse-output correction; the optimized output is
+bitwise identical to the original exact smoothing path.
 
 ~~~bash
 # BF16 dense

--- a/examples/minimax_h3/README.md
+++ b/examples/minimax_h3/README.md
@@ -419,7 +419,9 @@ The same FL2VA example exposes dense/Sol and BF16/FP8 as independent switches. `
 tf-kernel W8A8 Linear GEMMs to the transformer blocks. `--attn-impl SOL_ATTN` enables the MiniMax-H3 Sol policy:
 the first 10 denoising steps and first 2 DiT layers remain dense, the full condition prefix is an exact KV sink, and
 prefix queries are recomputed with BF16 dense attention. Adding `--sol-fp8` quantizes post-RoPE Q/K/V in active sparse
-layers and dispatches the SM90 CuTe FP8 Sol mainloop.
+layers and dispatches the SM90 CuTe FP8 Sol mainloop. The MiniMax-H3 quality profile also centers K and V over the live
+sequence before E4M3 conversion, adds the V mean back after attention, and corrects the residual V mean bias caused by
+E4M3 rounding. These are attention-equivalent transforms rather than Linear SmoothQuant.
 
 ~~~bash
 # BF16 dense
@@ -435,22 +437,23 @@ python -m examples.minimax_h3.minimax_h3_fl2va_h100 \
 
 # FP8 Linear + FP8 Sol attention
 python -m examples.minimax_h3.minimax_h3_fl2va_h100 \
-  --gpu-num 4 --mode t2va --quantization fp8 --attn-impl SOL_ATTN --sol-fp8 \
+  --gpu-num 1 --mode t2va --quantization fp8 --attn-impl SOL_ATTN --sol-fp8 \
   --output outputs/h3_fp8_sol.mp4
 ~~~
 
 Use `--sol-dense-steps`, `--sol-dense-layers`, `--sol-tau`, `--sol-threshold-type`,
-`--sol-fp8-layer-start`, and `--sol-fp8-layer-end` to override the policy for controlled ablations. The defaults
-match the released H100 MiniMax-H3 Sol profile.
+`--sol-fp8-layer-start`, and `--sol-fp8-layer-end` to override the policy for controlled ablations. Use
+`--sol-fp8-smoothing none|k|kv` and `--no-sol-fp8-v-bias-correction` to isolate the quality protections. The defaults
+use K+V smoothing and V bias correction for the H100 MiniMax-H3 Sol profile.
 
-For a warmed four-GPU comparison that saves synchronized MP4s, decoded arrays, throughput, and sampled device-memory
-peaks, run the two profiles below. Four GPUs use Ulysses2 x TP2 for both profiles.
+For a warmed matched comparison that saves synchronized MP4s, decoded arrays, throughput, and sampled device-memory
+peaks, run the two single-GPU profiles below. Pass `--gpu-num 4` to retain the earlier Ulysses2 x TP2 benchmark mode.
 
 ~~~bash
 python -m tools.validation.benchmark_minimax_h3_fp8_sol_sp \
-  --profile baseline --output benchmarks/minimax_h3_fp8_sol/baseline_sp2_tp2_bf16_flash.mp4
+  --gpu-num 1 --profile baseline --output benchmarks/minimax_h3_fp8_sol/baseline_bf16_flash.mp4
 python -m tools.validation.benchmark_minimax_h3_fp8_sol_sp \
-  --profile optimized --output benchmarks/minimax_h3_fp8_sol/optimized_sp2_tp2_fp8_sol_exact.mp4
+  --gpu-num 1 --profile optimized --output benchmarks/minimax_h3_fp8_sol/optimized_fp8_sol_exact.mp4
 ~~~
 
 For matched BF16/TorchAO-FP8/tf-kernel-FP8/NF4 profiling, use the validation benchmark. It writes the synchronized MP4 plus a JSON report

--- a/examples/minimax_h3/README.md
+++ b/examples/minimax_h3/README.md
@@ -444,9 +444,9 @@ python -m examples.minimax_h3.minimax_h3_fl2va_h100 \
 ~~~
 
 Use `--sol-dense-steps`, `--sol-dense-layers`, `--sol-tau`, `--sol-threshold-type`,
-`--sol-fp8-layer-start`, and `--sol-fp8-layer-end` to override the policy for controlled ablations. Use
-`--sol-fp8-smoothing none|k|kv` and `--no-sol-fp8-v-bias-correction` to isolate the quality protections. The defaults
-use K+V smoothing and V bias correction for the H100 MiniMax-H3 Sol profile.
+`--sol-fp8-layer-start`, and `--sol-fp8-layer-end` to override the policy for controlled ablations. FP8 Sol enables
+K+V smoothing and V bias correction by default, so the standard example needs no additional quality flags. The
+dedicated validation benchmark retains explicit overrides for comparing against an unsmoothed profile.
 
 For a warmed matched comparison that saves synchronized MP4s, decoded arrays, throughput, and sampled device-memory
 peaks, run the two single-GPU profiles below. Pass `--gpu-num 4` to retain the earlier Ulysses2 x TP2 benchmark mode.

--- a/examples/minimax_h3/common.py
+++ b/examples/minimax_h3/common.py
@@ -182,6 +182,8 @@ def load_minimax_h3_pipeline(
     sol_threshold_type: str = "exact",
     sol_fp8_layer_start: int = 0,
     sol_fp8_layer_end: int | None = None,
+    sol_fp8_smoothing: str = "kv",
+    sol_fp8_v_bias_correction: bool = True,
     feature_cache_config: FeatureCacheConfig | None = None,
     adaln_cache_path: str | Path | None = None,
     online_adaln_cache: bool = False,
@@ -278,6 +280,8 @@ def load_minimax_h3_pipeline(
             sol_fp8_layer_end=sol_fp8_layer_end,
             attention_chunks=attention_chunks,
             ulysses_sequence_mode=ulysses_sequence_mode,
+            sol_fp8_smoothing=sol_fp8_smoothing,
+            sol_fp8_v_bias_correction=sol_fp8_v_bias_correction,
         )
         if attn_impl == AttnImplType.SOL_ATTN
         else AttentionConfig.dense_attention(

--- a/examples/minimax_h3/minimax_h3_fl2va_h100.py
+++ b/examples/minimax_h3/minimax_h3_fl2va_h100.py
@@ -38,8 +38,6 @@ PPL_CONFIG: dict[str, Any] = {
     "attention_chunks": 2,
     "ulysses_sequence_mode": "valid_only",
     "sol_fp8": False,
-    "sol_fp8_smoothing": "kv",
-    "sol_fp8_v_bias_correction": True,
     "feature_cache_model_type": "MiniMax-H3-Base",
     "feature_cache_n_derivatives": 1,
     "feature_cache_taylor_threshold": 2,
@@ -101,8 +99,8 @@ def get_pipeline(
     sol_threshold_type: str = "exact",
     sol_fp8_layer_start: int = 0,
     sol_fp8_layer_end: int | None = None,
-    sol_fp8_smoothing: str = PPL_CONFIG["sol_fp8_smoothing"],
-    sol_fp8_v_bias_correction: bool = PPL_CONFIG["sol_fp8_v_bias_correction"],
+    sol_fp8_smoothing: str = "kv",
+    sol_fp8_v_bias_correction: bool = True,
     enable_feature_cache: bool = False,
     feature_cache_model_type: str = PPL_CONFIG["feature_cache_model_type"],
     feature_cache_n_derivatives: int = PPL_CONFIG["feature_cache_n_derivatives"],
@@ -334,18 +332,6 @@ def _main(default_quantization: str | None = PPL_CONFIG["quantization"]) -> None
     parser.add_argument("--sol-threshold-type", choices=("exact", "diag"), default="exact")
     parser.add_argument("--sol-fp8-layer-start", type=int, default=0)
     parser.add_argument("--sol-fp8-layer-end", type=int)
-    parser.add_argument(
-        "--sol-fp8-smoothing",
-        choices=("none", "k", "kv"),
-        default=PPL_CONFIG["sol_fp8_smoothing"],
-        help="Sequence-mean smoothing applied before FP8 QKV quantization.",
-    )
-    parser.add_argument(
-        "--sol-fp8-v-bias-correction",
-        action=argparse.BooleanOptionalAction,
-        default=PPL_CONFIG["sol_fp8_v_bias_correction"],
-        help="Correct the residual centered-V mean introduced by E4M3 rounding.",
-    )
     parser.add_argument("--enable-feature-cache", action="store_true")
     parser.add_argument("--feature-cache-model-type", default=PPL_CONFIG["feature_cache_model_type"])
     parser.add_argument(
@@ -399,8 +385,6 @@ def _main(default_quantization: str | None = PPL_CONFIG["quantization"]) -> None
         sol_threshold_type=args.sol_threshold_type,
         sol_fp8_layer_start=args.sol_fp8_layer_start,
         sol_fp8_layer_end=args.sol_fp8_layer_end,
-        sol_fp8_smoothing=args.sol_fp8_smoothing,
-        sol_fp8_v_bias_correction=args.sol_fp8_v_bias_correction,
         enable_feature_cache=args.enable_feature_cache,
         feature_cache_model_type=args.feature_cache_model_type,
         feature_cache_n_derivatives=args.feature_cache_n_derivatives,

--- a/examples/minimax_h3/minimax_h3_fl2va_h100.py
+++ b/examples/minimax_h3/minimax_h3_fl2va_h100.py
@@ -38,6 +38,8 @@ PPL_CONFIG: dict[str, Any] = {
     "attention_chunks": 2,
     "ulysses_sequence_mode": "valid_only",
     "sol_fp8": False,
+    "sol_fp8_smoothing": "kv",
+    "sol_fp8_v_bias_correction": True,
     "feature_cache_model_type": "MiniMax-H3-Base",
     "feature_cache_n_derivatives": 1,
     "feature_cache_taylor_threshold": 2,
@@ -99,6 +101,8 @@ def get_pipeline(
     sol_threshold_type: str = "exact",
     sol_fp8_layer_start: int = 0,
     sol_fp8_layer_end: int | None = None,
+    sol_fp8_smoothing: str = PPL_CONFIG["sol_fp8_smoothing"],
+    sol_fp8_v_bias_correction: bool = PPL_CONFIG["sol_fp8_v_bias_correction"],
     enable_feature_cache: bool = False,
     feature_cache_model_type: str = PPL_CONFIG["feature_cache_model_type"],
     feature_cache_n_derivatives: int = PPL_CONFIG["feature_cache_n_derivatives"],
@@ -129,6 +133,8 @@ def get_pipeline(
         sol_threshold_type=sol_threshold_type,
         sol_fp8_layer_start=sol_fp8_layer_start,
         sol_fp8_layer_end=sol_fp8_layer_end,
+        sol_fp8_smoothing=sol_fp8_smoothing,
+        sol_fp8_v_bias_correction=sol_fp8_v_bias_correction,
         feature_cache_config=FeatureCacheConfig(
             enabled=enable_feature_cache,
             model_type=feature_cache_model_type,
@@ -328,6 +334,18 @@ def _main(default_quantization: str | None = PPL_CONFIG["quantization"]) -> None
     parser.add_argument("--sol-threshold-type", choices=("exact", "diag"), default="exact")
     parser.add_argument("--sol-fp8-layer-start", type=int, default=0)
     parser.add_argument("--sol-fp8-layer-end", type=int)
+    parser.add_argument(
+        "--sol-fp8-smoothing",
+        choices=("none", "k", "kv"),
+        default=PPL_CONFIG["sol_fp8_smoothing"],
+        help="Sequence-mean smoothing applied before FP8 QKV quantization.",
+    )
+    parser.add_argument(
+        "--sol-fp8-v-bias-correction",
+        action=argparse.BooleanOptionalAction,
+        default=PPL_CONFIG["sol_fp8_v_bias_correction"],
+        help="Correct the residual centered-V mean introduced by E4M3 rounding.",
+    )
     parser.add_argument("--enable-feature-cache", action="store_true")
     parser.add_argument("--feature-cache-model-type", default=PPL_CONFIG["feature_cache_model_type"])
     parser.add_argument(
@@ -381,6 +399,8 @@ def _main(default_quantization: str | None = PPL_CONFIG["quantization"]) -> None
         sol_threshold_type=args.sol_threshold_type,
         sol_fp8_layer_start=args.sol_fp8_layer_start,
         sol_fp8_layer_end=args.sol_fp8_layer_end,
+        sol_fp8_smoothing=args.sol_fp8_smoothing,
+        sol_fp8_v_bias_correction=args.sol_fp8_v_bias_correction,
         enable_feature_cache=args.enable_feature_cache,
         feature_cache_model_type=args.feature_cache_model_type,
         feature_cache_n_derivatives=args.feature_cache_n_derivatives,

--- a/telefuser/core/config.py
+++ b/telefuser/core/config.py
@@ -154,6 +154,8 @@ class SparseAttentionConfig:
     sol_fp8: bool = False  # Quantize post-RoPE Q/K/V activations for FP8 Sol-Attn
     sol_fp8_layer_start: int = 0  # First transformer layer using FP8 Sol-Attn
     sol_fp8_layer_end: int | None = None  # Exclusive end; None enables all remaining layers
+    sol_fp8_smoothing: str = "none"  # Sequence-mean smoothing: "none", "k", or "kv"
+    sol_fp8_v_bias_correction: bool = False  # Correct residual V mean after E4M3 rounding
 
     def __post_init__(self) -> None:
         if self.sparse_impl != "sol":
@@ -166,6 +168,10 @@ class SparseAttentionConfig:
             raise ValueError("Sol-Attn FP8 layer start must be non-negative")
         if self.sol_fp8_layer_end is not None and self.sol_fp8_layer_end <= self.sol_fp8_layer_start:
             raise ValueError("Sol-Attn FP8 layer end must be greater than its start")
+        if self.sol_fp8_smoothing not in ("none", "k", "kv"):
+            raise ValueError("Sol-Attn FP8 smoothing must be 'none', 'k', or 'kv'")
+        if self.sol_fp8_v_bias_correction and self.sol_fp8_smoothing != "kv":
+            raise ValueError("Sol-Attn FP8 V bias correction requires smoothing='kv'")
 
     def should_use_dense(self, numeral_timestep: int, layer_idx: int) -> bool:
         """Check if dense attention should be used for current step/layer.
@@ -247,6 +253,8 @@ class AttentionConfig:
         sol_fp8: bool = False,
         sol_fp8_layer_start: int = 0,
         sol_fp8_layer_end: int | None = None,
+        sol_fp8_smoothing: str = "none",
+        sol_fp8_v_bias_correction: bool = False,
         **kwargs: any,
     ) -> AttentionConfig:
         """Create a Sol-Attn config for dynamic sparse video self-attention."""
@@ -262,6 +270,8 @@ class AttentionConfig:
                 sol_fp8=sol_fp8,
                 sol_fp8_layer_start=sol_fp8_layer_start,
                 sol_fp8_layer_end=sol_fp8_layer_end,
+                sol_fp8_smoothing=sol_fp8_smoothing,
+                sol_fp8_v_bias_correction=sol_fp8_v_bias_correction,
             ),
             **kwargs,
         )

--- a/telefuser/core/config.py
+++ b/telefuser/core/config.py
@@ -253,8 +253,8 @@ class AttentionConfig:
         sol_fp8: bool = False,
         sol_fp8_layer_start: int = 0,
         sol_fp8_layer_end: int | None = None,
-        sol_fp8_smoothing: str = "none",
-        sol_fp8_v_bias_correction: bool = False,
+        sol_fp8_smoothing: str = "kv",
+        sol_fp8_v_bias_correction: bool = True,
         **kwargs: any,
     ) -> AttentionConfig:
         """Create a Sol-Attn config for dynamic sparse video self-attention."""

--- a/telefuser/models/minimax_h3_dit.py
+++ b/telefuser/models/minimax_h3_dit.py
@@ -36,7 +36,11 @@ from telefuser.distributed.ulysses_comm import (
 from telefuser.feature_cache import AdaTaylorCacheCalibrator, NoOpCache
 from telefuser.ops import RMSNorm, apply_qk_norm_rope_neox, indexed_gate, indexed_scale_shift, silu_and_mul_reuse_input
 from telefuser.ops.attention import SparseAttentionState, attention
-from telefuser.ops.fp8_attention import apply_fp8_attention_output_correction, quantize_fp8_qkv_smoothed
+from telefuser.ops.fp8_attention import (
+    apply_fp8_attention_output_correction,
+    merge_fp8_attention_prefix,
+    quantize_fp8_qkv_smoothed,
+)
 from telefuser.ops.rotary import apply_rotary_emb_neox
 from telefuser.utils.logging import logger
 
@@ -709,8 +713,6 @@ class MiniMaxH3Attention(nn.Module):
                     sink_start=0,
                     sink_tokens=prefix_tokens,
                 )
-                if output_correction is not None:
-                    live_output = apply_fp8_attention_output_correction(live_output, output_correction)
                 if self._is_sol_active(sparse_state) and prefix_tokens:
                     dense_prefix = F.scaled_dot_product_attention(
                         live_query[:, :prefix_tokens].transpose(1, 2),
@@ -718,7 +720,12 @@ class MiniMaxH3Attention(nn.Module):
                         live_value.transpose(1, 2),
                         scale=self.head_dim**-0.5,
                     ).transpose(1, 2)
-                    live_output = torch.cat((dense_prefix, live_output[:, prefix_tokens:]), dim=1)
+                    if output_correction is None:
+                        live_output = torch.cat((dense_prefix, live_output[:, prefix_tokens:]), dim=1)
+                    else:
+                        live_output = merge_fp8_attention_prefix(dense_prefix, live_output, output_correction)
+                elif output_correction is not None:
+                    live_output = apply_fp8_attention_output_correction(live_output, output_correction)
                 if live_tokens == total_tokens:
                     output = live_output
                 else:

--- a/telefuser/models/minimax_h3_dit.py
+++ b/telefuser/models/minimax_h3_dit.py
@@ -36,7 +36,7 @@ from telefuser.distributed.ulysses_comm import (
 from telefuser.feature_cache import AdaTaylorCacheCalibrator, NoOpCache
 from telefuser.ops import RMSNorm, apply_qk_norm_rope_neox, indexed_gate, indexed_scale_shift, silu_and_mul_reuse_input
 from telefuser.ops.attention import SparseAttentionState, attention
-from telefuser.ops.fp8_attention import quantize_fp8_per_block, quantize_fp8_qkv
+from telefuser.ops.fp8_attention import apply_fp8_attention_output_correction, quantize_fp8_qkv_smoothed
 from telefuser.ops.rotary import apply_rotary_emb_neox
 from telefuser.utils.logging import logger
 
@@ -536,6 +536,7 @@ class MiniMaxH3Attention(nn.Module):
         torch.Tensor,
         torch.Tensor,
         tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None,
+        torch.Tensor | None,
     ]:
         config = sparse_state.config
         layer_end = config.sol_fp8_layer_end
@@ -546,14 +547,15 @@ class MiniMaxH3Attention(nn.Module):
             and (layer_end is None or sparse_state.layer_idx < layer_end)
         )
         if not fp8_layer_active:
-            return query, key, value, None
-        if query.is_cuda and torch.cuda.get_device_capability(query.device) == (9, 0):
-            query, key, value, q_scale, k_scale, v_scale = quantize_fp8_qkv(query, key, value)
-        else:
-            query, q_scale = quantize_fp8_per_block(query)
-            key, k_scale = quantize_fp8_per_block(key)
-            value, v_scale = quantize_fp8_per_block(value)
-        return query, key, value, (q_scale, k_scale, v_scale)
+            return query, key, value, None, None
+        query, key, value, q_scale, k_scale, v_scale, output_correction = quantize_fp8_qkv_smoothed(
+            query,
+            key,
+            value,
+            smoothing=config.sol_fp8_smoothing,
+            correct_v_bias=config.sol_fp8_v_bias_correction,
+        )
+        return query, key, value, (q_scale, k_scale, v_scale), output_correction
 
     def forward(
         self,
@@ -675,6 +677,7 @@ class MiniMaxH3Attention(nn.Module):
                 live_key = key[:, :live_tokens].contiguous()
                 live_value = value[:, :live_tokens].contiguous()
                 scales = None
+                output_correction = None
                 runtime_attention_config = attention_config
                 runtime_sparse_state = sparse_state
                 if attention_config.attn_impl == AttnImplType.SOL_ATTN:
@@ -682,8 +685,11 @@ class MiniMaxH3Attention(nn.Module):
                         raise RuntimeError("MiniMax H3 Sol-Attn requires sparse runtime state")
                     if not 0 <= prefix_tokens <= live_tokens:
                         raise ValueError("MiniMax H3 Sol-Attn prefix must be within the live packed sequence")
-                    sol_query, sol_key, sol_value, scales = self._prepare_sol_qkv(
-                        live_query, live_key, live_value, sparse_state
+                    sol_query, sol_key, sol_value, scales, output_correction = self._prepare_sol_qkv(
+                        live_query,
+                        live_key,
+                        live_value,
+                        sparse_state,
                     )
                     if sparse_state.should_use_dense():
                         runtime_attention_config = AttentionConfig.dense_attention(AttnImplType.FLASH_ATTN_4)
@@ -703,6 +709,8 @@ class MiniMaxH3Attention(nn.Module):
                     sink_start=0,
                     sink_tokens=prefix_tokens,
                 )
+                if output_correction is not None:
+                    live_output = apply_fp8_attention_output_correction(live_output, output_correction)
                 if self._is_sol_active(sparse_state) and prefix_tokens:
                     dense_prefix = F.scaled_dot_product_attention(
                         live_query[:, :prefix_tokens].transpose(1, 2),

--- a/telefuser/ops/fp8_attention.py
+++ b/telefuser/ops/fp8_attention.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import torch
 import torch.nn.functional as F
 import triton
@@ -11,10 +13,72 @@ FP8_ATTENTION_BLOCK_SIZE = 64
 
 
 @triton.jit
+def _sequence_mean_kernel(
+    x,
+    output,
+    tokens: tl.constexpr,
+    heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    stride_batch,
+    stride_token,
+    stride_head,
+    stride_dim,
+    block_tokens: tl.constexpr,
+    block_dim: tl.constexpr,
+):
+    batch_head = tl.program_id(0)
+    dim_block = tl.program_id(1)
+    batch = batch_head // heads
+    head = batch_head % heads
+    dims = dim_block * block_dim + tl.arange(0, block_dim)
+    valid_dims = dims < head_dim
+    total = tl.zeros((block_dim,), dtype=tl.float32)
+    for start in range(0, tokens, block_tokens):
+        token_offsets = start + tl.arange(0, block_tokens)
+        valid_tokens = token_offsets < tokens
+        offsets = (
+            batch * stride_batch
+            + token_offsets[:, None] * stride_token
+            + head * stride_head
+            + dims[None, :] * stride_dim
+        )
+        values = tl.load(
+            x + offsets,
+            mask=valid_tokens[:, None] & valid_dims[None, :],
+            other=0.0,
+        ).to(tl.float32)
+        total += tl.sum(values, axis=0)
+    tl.store(output + batch_head * head_dim + dims, total / tokens, mask=valid_dims)
+
+
+@triton.jit
+def _add_output_correction_kernel(
+    output,
+    correction,
+    elements,
+    tokens: tl.constexpr,
+    heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    block: tl.constexpr,
+):
+    offsets = tl.program_id(0) * block + tl.arange(0, block)
+    valid = offsets < elements
+    batch = offsets // (tokens * heads * head_dim)
+    head = (offsets // head_dim) % heads
+    dim = offsets % head_dim
+    correction_offsets = (batch * heads + head) * head_dim + dim
+    values = tl.load(output + offsets, mask=valid).to(tl.float32)
+    shift = tl.load(correction + correction_offsets, mask=valid)
+    tl.store(output + offsets, values + shift, mask=valid)
+
+
+@triton.jit
 def _quantize_qkv_fp8_stage1(
     q,
     k,
     v,
+    k_mean,
+    v_mean,
     q_out,
     k_out,
     q_scale,
@@ -24,6 +88,8 @@ def _quantize_qkv_fp8_stage1(
     heads: tl.constexpr,
     head_dim: tl.constexpr,
     block: tl.constexpr,
+    smooth_k: tl.constexpr,
+    smooth_v: tl.constexpr,
 ):
     block_idx = tl.program_id(0)
     batch_head = tl.program_id(1)
@@ -36,6 +102,19 @@ def _quantize_qkv_fp8_stage1(
     q_values = tl.load(q + offsets, mask=valid[:, None], other=0.0).to(tl.float32)
     k_values = tl.load(k + offsets, mask=valid[:, None], other=0.0).to(tl.float32)
     v_values = tl.load(v + offsets, mask=valid[:, None], other=0.0).to(tl.float32)
+    mean_offsets = batch_head * head_dim + dim_offsets
+    if smooth_k:
+        k_values = tl.where(
+            valid[:, None],
+            k_values - tl.load(k_mean + mean_offsets)[None, :],
+            0.0,
+        )
+    if smooth_v:
+        v_values = tl.where(
+            valid[:, None],
+            v_values - tl.load(v_mean + mean_offsets)[None, :],
+            0.0,
+        )
 
     q_s = tl.maximum(tl.max(tl.max(tl.abs(q_values), axis=1), axis=0), 1.0e-6) / 448.0
     k_s = tl.maximum(tl.max(tl.max(tl.abs(k_values), axis=1), axis=0), 1.0e-6) / 448.0
@@ -53,12 +132,14 @@ def _quantize_qkv_fp8_stage1(
 @triton.jit
 def _quantize_qkv_fp8_stage2_v(
     v,
+    v_mean,
     v_out,
     v_scale,
     tokens: tl.constexpr,
     heads: tl.constexpr,
     head_dim: tl.constexpr,
     block: tl.constexpr,
+    smooth_v: tl.constexpr,
 ):
     block_idx = tl.program_id(0)
     batch_head = tl.program_id(1)
@@ -72,15 +153,46 @@ def _quantize_qkv_fp8_stage2_v(
     scale_offsets = (batch * heads + head) * head_dim + dim_offsets
     scale = tl.maximum(tl.load(v_scale + scale_offsets), 1.0e-6 / 448.0)
     values = tl.load(v + input_offsets, mask=valid[:, None], other=0.0).to(tl.float32)
+    if smooth_v:
+        values = values - tl.load(v_mean + scale_offsets)[None, :]
     tl.store(v_out + output_offsets, values / scale[None, :], mask=valid[:, None])
 
 
-def quantize_fp8_qkv(
+def _sequence_mean(x: torch.Tensor) -> torch.Tensor:
+    """Reduce BTHD sequence means in FP32 without materializing an FP32 copy."""
+
+    if x.ndim != 4 or not x.is_floating_point():
+        raise ValueError("attention smoothing expects a floating-point [B, T, H, D] tensor")
+    if not x.is_cuda:
+        return x.float().mean(dim=1)
+    batch, tokens, heads, head_dim = x.shape
+    output = torch.empty((batch, heads, head_dim), device=x.device, dtype=torch.float32)
+    block_tokens = 128
+    block_dim = 32
+    _sequence_mean_kernel[(batch * heads, triton.cdiv(head_dim, block_dim))](
+        x,
+        output,
+        tokens,
+        heads,
+        head_dim,
+        *x.stride(),
+        block_tokens,
+        block_dim,
+        num_warps=4,
+        num_stages=1,
+    )
+    return output
+
+
+def _quantize_fp8_qkv_sm90(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
+    *,
+    k_mean: torch.Tensor | None = None,
+    v_mean: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Fused SM90 block-scaled Q/K and layout-aware V-channel E4M3 quantization."""
+    """Run fused SM90 QKV quantization with optional sequence-mean shifts."""
 
     if q.shape != k.shape or q.shape != v.shape or q.ndim != 4:
         raise ValueError("q, k, and v must share shape [B, T, H, D]")
@@ -96,11 +208,14 @@ def quantize_fp8_qkv(
     q_scale = torch.empty((batch, blocks, heads), device=q.device, dtype=torch.float32)
     k_scale = torch.ones_like(q_scale)
     v_scale = torch.zeros((batch, heads, head_dim), device=q.device, dtype=torch.float32)
+    dummy_mean = torch.empty((1,), device=q.device, dtype=torch.float32)
     grid = (blocks, batch * heads)
     _quantize_qkv_fp8_stage1[grid](
         q,
         k,
         v,
+        dummy_mean if k_mean is None else k_mean,
+        dummy_mean if v_mean is None else v_mean,
         q_out,
         k_out,
         q_scale,
@@ -110,22 +225,36 @@ def quantize_fp8_qkv(
         heads,
         head_dim,
         FP8_ATTENTION_BLOCK_SIZE,
+        smooth_k=k_mean is not None,
+        smooth_v=v_mean is not None,
         num_warps=8,
         num_stages=1,
     )
     _quantize_qkv_fp8_stage2_v[grid](
         v,
+        dummy_mean if v_mean is None else v_mean,
         v_storage,
         v_scale,
         tokens,
         heads,
         head_dim,
         FP8_ATTENTION_BLOCK_SIZE,
+        smooth_v=v_mean is not None,
         num_warps=8,
         num_stages=1,
     )
     v_out = v_storage.permute(0, 3, 1, 2)
     return q_out, k_out, v_out, q_scale, k_scale, v_scale
+
+
+def quantize_fp8_qkv(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Fused SM90 block-scaled Q/K and layout-aware V-channel E4M3 quantization."""
+
+    return _quantize_fp8_qkv_sm90(q, k, v)
 
 
 def quantize_fp8_per_block(
@@ -205,12 +334,102 @@ def dequantize_fp8_per_channel(
     return x.to(dtype) * scale.to(dtype).unsqueeze(1)
 
 
+def quantize_fp8_qkv_smoothed(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    smoothing: Literal["none", "k", "kv"] = "kv",
+    correct_v_bias: bool = True,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor | None,
+]:
+    """Quantize QKV after attention-equivalent sequence-mean smoothing.
+
+    Subtracting one sequence mean from every key shifts each query's logits by
+    a constant, leaving softmax probabilities unchanged. Centering values is
+    also equivalent when their mean is added back to the attention output.
+    ``correct_v_bias`` additionally removes the mean error introduced when the
+    centered values are rounded to E4M3.
+    """
+
+    if smoothing not in ("none", "k", "kv"):
+        raise ValueError("FP8 attention smoothing must be 'none', 'k', or 'kv'")
+    if correct_v_bias and smoothing != "kv":
+        raise ValueError("FP8 value bias correction requires smoothing='kv'")
+    if q.shape != k.shape or q.shape != v.shape or q.ndim != 4:
+        raise ValueError("q, k, and v must share shape [B, T, H, D]")
+
+    k_mean = _sequence_mean(k) if smoothing in ("k", "kv") else None
+    v_mean = _sequence_mean(v) if smoothing == "kv" else None
+    native_sm90 = q.is_cuda and torch.cuda.get_device_capability(q.device) == (9, 0)
+    if native_sm90:
+        quantized = _quantize_fp8_qkv_sm90(q, k, v, k_mean=k_mean, v_mean=v_mean)
+    else:
+        centered_k = k if k_mean is None else k - k_mean.to(k.dtype).unsqueeze(1)
+        centered_v = v if v_mean is None else v - v_mean.to(v.dtype).unsqueeze(1)
+        q_out, q_scale = quantize_fp8_per_block(q)
+        k_out, k_scale = quantize_fp8_per_block(centered_k.contiguous())
+        v_out, v_scale = quantize_fp8_per_block(centered_v.contiguous())
+        quantized = q_out, k_out, v_out, q_scale, k_scale, v_scale
+
+    q_out, k_out, v_out, q_scale, k_scale, v_scale = quantized
+    output_correction = None
+    if v_mean is not None:
+        output_correction = v_mean
+        if correct_v_bias:
+            if v_scale.shape == (v.shape[0], v.shape[2], v.shape[3]):
+                quantized_v_mean = _sequence_mean(v_out) * v_scale
+            else:
+                restored_v = dequantize_fp8_per_block(v_out, v_scale, torch.bfloat16)
+                quantized_v_mean = _sequence_mean(restored_v)
+            output_correction = output_correction - quantized_v_mean
+        output_correction = output_correction.unsqueeze(1).contiguous()
+    return q_out, k_out, v_out, q_scale, k_scale, v_scale, output_correction
+
+
+def apply_fp8_attention_output_correction(output: torch.Tensor, correction: torch.Tensor) -> torch.Tensor:
+    """Add an FP32 per-head value correction and store back in output dtype."""
+
+    if output.ndim != 4 or correction.shape != (output.shape[0], 1, output.shape[2], output.shape[3]):
+        raise ValueError("FP8 attention correction must have shape [B, 1, H, D] for a [B, T, H, D] output")
+    if correction.dtype != torch.float32 or correction.device != output.device:
+        raise ValueError("FP8 attention correction must be FP32 on the output device")
+    if not output.is_cuda:
+        return (output.float() + correction).to(output.dtype)
+    if not output.is_contiguous() or not correction.is_contiguous():
+        raise ValueError("FP8 attention output and correction must be contiguous")
+    batch, tokens, heads, head_dim = output.shape
+    elements = output.numel()
+    block = 256
+    _add_output_correction_kernel[(triton.cdiv(elements, block),)](
+        output,
+        correction,
+        elements,
+        tokens,
+        heads,
+        head_dim,
+        block,
+        num_warps=4,
+        num_stages=1,
+    )
+    return output
+
+
 __all__ = [
     "FP8_ATTENTION_BLOCK_SIZE",
+    "apply_fp8_attention_output_correction",
     "dequantize_fp8_per_block",
     "dequantize_fp8_per_channel",
     "dequantize_fp8_per_token",
     "quantize_fp8_qkv",
+    "quantize_fp8_qkv_smoothed",
     "quantize_fp8_per_block",
     "quantize_fp8_per_channel",
 ]

--- a/telefuser/ops/fp8_attention.py
+++ b/telefuser/ops/fp8_attention.py
@@ -52,6 +52,59 @@ def _sequence_mean_kernel(
 
 
 @triton.jit
+def _sequence_mean_kv_kernel(
+    k,
+    v,
+    k_output,
+    v_output,
+    tokens: tl.constexpr,
+    heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    k_stride_batch,
+    k_stride_token,
+    k_stride_head,
+    k_stride_dim,
+    v_stride_batch,
+    v_stride_token,
+    v_stride_head,
+    v_stride_dim,
+    block_tokens: tl.constexpr,
+    block_dim: tl.constexpr,
+):
+    batch_head = tl.program_id(0)
+    dim_block = tl.program_id(1)
+    batch = batch_head // heads
+    head = batch_head % heads
+    dims = dim_block * block_dim + tl.arange(0, block_dim)
+    valid_dims = dims < head_dim
+    k_total = tl.zeros((block_dim,), dtype=tl.float32)
+    v_total = tl.zeros((block_dim,), dtype=tl.float32)
+    for start in range(0, tokens, block_tokens):
+        token_offsets = start + tl.arange(0, block_tokens)
+        valid_tokens = token_offsets < tokens
+        k_offsets = (
+            batch * k_stride_batch
+            + token_offsets[:, None] * k_stride_token
+            + head * k_stride_head
+            + dims[None, :] * k_stride_dim
+        )
+        v_offsets = (
+            batch * v_stride_batch
+            + token_offsets[:, None] * v_stride_token
+            + head * v_stride_head
+            + dims[None, :] * v_stride_dim
+        )
+        mask = valid_tokens[:, None] & valid_dims[None, :]
+        k_values = tl.load(k + k_offsets, mask=mask, other=0.0).to(tl.float32)
+        v_values = tl.load(v + v_offsets, mask=mask, other=0.0).to(tl.float32)
+        k_total += tl.sum(k_values, axis=0)
+        v_total += tl.sum(v_values, axis=0)
+    output_offsets = batch_head * head_dim + dims
+    tl.store(k_output + output_offsets, k_total / tokens, mask=valid_dims)
+    tl.store(v_output + output_offsets, v_total / tokens, mask=valid_dims)
+
+
+@triton.jit
 def _add_output_correction_kernel(
     output,
     correction,
@@ -70,6 +123,34 @@ def _add_output_correction_kernel(
     values = tl.load(output + offsets, mask=valid).to(tl.float32)
     shift = tl.load(correction + correction_offsets, mask=valid)
     tl.store(output + offsets, values + shift, mask=valid)
+
+
+@triton.jit
+def _merge_prefix_output_correction_kernel(
+    prefix,
+    output,
+    correction,
+    merged,
+    elements,
+    prefix_tokens: tl.constexpr,
+    tokens: tl.constexpr,
+    heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    block: tl.constexpr,
+):
+    offsets = tl.program_id(0) * block + tl.arange(0, block)
+    valid = offsets < elements
+    batch = offsets // (tokens * heads * head_dim)
+    token = (offsets // (heads * head_dim)) % tokens
+    head = (offsets // head_dim) % heads
+    dim = offsets % head_dim
+    prefix_offsets = ((batch * prefix_tokens + token) * heads + head) * head_dim + dim
+    correction_offsets = (batch * heads + head) * head_dim + dim
+    prefix_values = tl.load(prefix + prefix_offsets, mask=valid & (token < prefix_tokens), other=0.0)
+    output_values = tl.load(output + offsets, mask=valid & (token >= prefix_tokens), other=0.0).to(tl.float32)
+    shift = tl.load(correction + correction_offsets, mask=valid & (token >= prefix_tokens), other=0.0)
+    values = tl.where(token < prefix_tokens, prefix_values, output_values + shift)
+    tl.store(merged + offsets, values, mask=valid)
 
 
 @triton.jit
@@ -182,6 +263,38 @@ def _sequence_mean(x: torch.Tensor) -> torch.Tensor:
         num_stages=1,
     )
     return output
+
+
+def _sequence_means(k: torch.Tensor, v: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reduce matching K/V sequence means in one GPU kernel launch."""
+
+    if k.shape != v.shape or k.ndim != 4 or not (k.is_floating_point() and v.is_floating_point()):
+        raise ValueError("K/V attention smoothing expects matching floating-point [B, T, H, D] tensors")
+    if k.device != v.device:
+        raise ValueError("K and V must be on the same device")
+    if not k.is_cuda:
+        return k.float().mean(dim=1), v.float().mean(dim=1)
+    batch, tokens, heads, head_dim = k.shape
+    k_output = torch.empty((batch, heads, head_dim), device=k.device, dtype=torch.float32)
+    v_output = torch.empty_like(k_output)
+    block_tokens = 128
+    block_dim = 32
+    _sequence_mean_kv_kernel[(batch * heads, triton.cdiv(head_dim, block_dim))](
+        k,
+        v,
+        k_output,
+        v_output,
+        tokens,
+        heads,
+        head_dim,
+        *k.stride(),
+        *v.stride(),
+        block_tokens,
+        block_dim,
+        num_warps=4,
+        num_stages=1,
+    )
+    return k_output, v_output
 
 
 def _quantize_fp8_qkv_sm90(
@@ -366,8 +479,11 @@ def quantize_fp8_qkv_smoothed(
     if q.shape != k.shape or q.shape != v.shape or q.ndim != 4:
         raise ValueError("q, k, and v must share shape [B, T, H, D]")
 
-    k_mean = _sequence_mean(k) if smoothing in ("k", "kv") else None
-    v_mean = _sequence_mean(v) if smoothing == "kv" else None
+    if smoothing == "kv":
+        k_mean, v_mean = _sequence_means(k, v)
+    else:
+        k_mean = _sequence_mean(k) if smoothing == "k" else None
+        v_mean = None
     native_sm90 = q.is_cuda and torch.cuda.get_device_capability(q.device) == (9, 0)
     if native_sm90:
         quantized = _quantize_fp8_qkv_sm90(q, k, v, k_mean=k_mean, v_mean=v_mean)
@@ -422,6 +538,54 @@ def apply_fp8_attention_output_correction(output: torch.Tensor, correction: torc
     return output
 
 
+def merge_fp8_attention_prefix(
+    dense_prefix: torch.Tensor,
+    output: torch.Tensor,
+    correction: torch.Tensor,
+) -> torch.Tensor:
+    """Merge a dense prefix with a corrected sparse suffix in one output pass."""
+
+    if dense_prefix.ndim != 4 or output.ndim != 4:
+        raise ValueError("attention prefix merge expects [B, T, H, D] tensors")
+    if dense_prefix.shape[0] != output.shape[0] or dense_prefix.shape[2:] != output.shape[2:]:
+        raise ValueError("dense prefix and sparse output must share batch, head, and head-dimension shapes")
+    prefix_tokens = dense_prefix.shape[1]
+    if not 0 < prefix_tokens <= output.shape[1]:
+        raise ValueError("dense attention prefix must be non-empty and no longer than the sparse output")
+    expected_correction = (output.shape[0], 1, output.shape[2], output.shape[3])
+    if correction.shape != expected_correction or correction.dtype != torch.float32:
+        raise ValueError("FP8 attention correction must be FP32 with shape [B, 1, H, D]")
+    if dense_prefix.device != output.device or correction.device != output.device:
+        raise ValueError("dense prefix, sparse output, and correction must be on the same device")
+    if dense_prefix.dtype != output.dtype:
+        raise ValueError("dense prefix and sparse output must have the same dtype")
+    if not output.is_cuda:
+        corrected_suffix = (output[:, prefix_tokens:].float() + correction).to(output.dtype)
+        return torch.cat((dense_prefix, corrected_suffix), dim=1)
+    if not (dense_prefix.is_contiguous() and output.is_contiguous() and correction.is_contiguous()):
+        raise ValueError("FP8 attention prefix merge inputs must be contiguous")
+
+    merged = torch.empty_like(output)
+    batch, tokens, heads, head_dim = output.shape
+    elements = output.numel()
+    block = 256
+    _merge_prefix_output_correction_kernel[(triton.cdiv(elements, block),)](
+        dense_prefix,
+        output,
+        correction,
+        merged,
+        elements,
+        prefix_tokens,
+        tokens,
+        heads,
+        head_dim,
+        block,
+        num_warps=4,
+        num_stages=1,
+    )
+    return merged
+
+
 __all__ = [
     "FP8_ATTENTION_BLOCK_SIZE",
     "apply_fp8_attention_output_correction",
@@ -430,6 +594,7 @@ __all__ = [
     "dequantize_fp8_per_token",
     "quantize_fp8_qkv",
     "quantize_fp8_qkv_smoothed",
+    "merge_fp8_attention_prefix",
     "quantize_fp8_per_block",
     "quantize_fp8_per_channel",
 ]

--- a/tests/unit/models/test_minimax_h3_dit.py
+++ b/tests/unit/models/test_minimax_h3_dit.py
@@ -308,6 +308,58 @@ def test_sol_fp8_applies_value_smoothing_correction_before_output_projection() -
     assert torch.count_nonzero(output[61:]) == 0
 
 
+def test_sol_fp8_fuses_dense_prefix_with_corrected_sparse_suffix() -> None:
+    module = MiniMaxH3Attention(_small_config()).eval()
+    module.out_proj = torch.nn.Identity()
+    hidden = torch.randn(64, 32, dtype=torch.bfloat16)
+    config = AttentionConfig.sol_attention(
+        dense_timesteps=0,
+        dense_layers=0,
+        threshold_type="exact",
+        sol_fp8=True,
+        sol_fp8_smoothing="kv",
+        sol_fp8_v_bias_correction=True,
+    )
+    state = SparseAttentionState(config.sparse_config, mask_map=None, model_type="minimax_h3")
+    scale = torch.ones(1, 1, 4)
+
+    def quantize(query: torch.Tensor, key: torch.Tensor, value: torch.Tensor, **_: object) -> tuple[torch.Tensor, ...]:
+        correction = torch.full((1, 1, 4, 8), 2.0)
+        return (
+            query.to(torch.float8_e4m3fn),
+            key.to(torch.float8_e4m3fn),
+            value.to(torch.float8_e4m3fn),
+            scale,
+            scale,
+            scale,
+            correction,
+        )
+
+    with (
+        patch("telefuser.models.minimax_h3_dit.quantize_fp8_qkv_smoothed", side_effect=quantize),
+        patch(
+            "telefuser.models.minimax_h3_dit.attention",
+            side_effect=lambda query, *_args, **_kwargs: torch.zeros(query.shape, dtype=torch.bfloat16),
+        ),
+        patch(
+            "telefuser.models.minimax_h3_dit.F.scaled_dot_product_attention",
+            side_effect=lambda query, *_args, **_kwargs: torch.ones_like(query),
+        ),
+    ):
+        output = module(
+            hidden,
+            sequence_lengths=[61, 3],
+            rope_cos_sin_cache=None,
+            attention_config=config,
+            sparse_state=state,
+            prefix_tokens=13,
+        )
+
+    torch.testing.assert_close(output[:13], torch.ones_like(output[:13]))
+    torch.testing.assert_close(output[13:61], torch.full_like(output[13:61], 2.0))
+    assert torch.count_nonzero(output[61:]) == 0
+
+
 def test_minimax_h3_initializes_sol_runtime_state() -> None:
     model = MiniMaxH3DiT(_small_config())
     config = AttentionConfig.sol_attention(dense_timesteps=10, dense_layers=2, threshold_type="exact")

--- a/tests/unit/models/test_minimax_h3_dit.py
+++ b/tests/unit/models/test_minimax_h3_dit.py
@@ -220,15 +220,28 @@ def test_sol_fp8_passes_quantized_qkv_scales_to_attention() -> None:
         dense_layers=0,
         threshold_type="exact",
         sol_fp8=True,
+        sol_fp8_smoothing="kv",
+        sol_fp8_v_bias_correction=True,
     )
     state = SparseAttentionState(config.sparse_config, mask_map=None, model_type="minimax_h3")
     scales = [torch.ones(1, 1, 4) * value for value in (1, 2, 3)]
 
-    def quantize(value: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        return value.to(torch.float8_e4m3fn), scales.pop(0)
+    def quantize(
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        **_: object,
+    ) -> tuple[torch.Tensor, ...]:
+        return (
+            query.to(torch.float8_e4m3fn),
+            key.to(torch.float8_e4m3fn),
+            value.to(torch.float8_e4m3fn),
+            *scales,
+            None,
+        )
 
     with (
-        patch("telefuser.models.minimax_h3_dit.quantize_fp8_per_block", side_effect=quantize),
+        patch("telefuser.models.minimax_h3_dit.quantize_fp8_qkv_smoothed", side_effect=quantize) as quantize_call,
         patch(
             "telefuser.models.minimax_h3_dit.attention",
             side_effect=lambda query, *_args, **_kwargs: query.float(),
@@ -246,6 +259,53 @@ def test_sol_fp8_passes_quantized_qkv_scales_to_attention() -> None:
     assert attention_call.call_args.kwargs["q_scale"].flatten()[0].item() == 1
     assert attention_call.call_args.kwargs["k_scale"].flatten()[0].item() == 2
     assert attention_call.call_args.kwargs["v_scale"].flatten()[0].item() == 3
+    assert quantize_call.call_args.kwargs == {"smoothing": "kv", "correct_v_bias": True}
+
+
+def test_sol_fp8_applies_value_smoothing_correction_before_output_projection() -> None:
+    module = MiniMaxH3Attention(_small_config()).eval()
+    module.out_proj = torch.nn.Identity()
+    hidden = torch.randn(64, 32, dtype=torch.bfloat16)
+    config = AttentionConfig.sol_attention(
+        dense_timesteps=0,
+        dense_layers=0,
+        threshold_type="exact",
+        sol_fp8=True,
+        sol_fp8_smoothing="kv",
+        sol_fp8_v_bias_correction=True,
+    )
+    state = SparseAttentionState(config.sparse_config, mask_map=None, model_type="minimax_h3")
+    scale = torch.ones(1, 1, 4)
+
+    def quantize(query: torch.Tensor, key: torch.Tensor, value: torch.Tensor, **_: object) -> tuple[torch.Tensor, ...]:
+        correction = torch.full((1, 1, 4, 8), 2.0)
+        return (
+            query.to(torch.float8_e4m3fn),
+            key.to(torch.float8_e4m3fn),
+            value.to(torch.float8_e4m3fn),
+            scale,
+            scale,
+            scale,
+            correction,
+        )
+
+    with (
+        patch("telefuser.models.minimax_h3_dit.quantize_fp8_qkv_smoothed", side_effect=quantize),
+        patch(
+            "telefuser.models.minimax_h3_dit.attention",
+            side_effect=lambda query, *_args, **_kwargs: torch.zeros(query.shape, dtype=torch.bfloat16),
+        ),
+    ):
+        output = module(
+            hidden,
+            sequence_lengths=[61, 3],
+            rope_cos_sin_cache=None,
+            attention_config=config,
+            sparse_state=state,
+        )
+
+    torch.testing.assert_close(output[:61], torch.full_like(output[:61], 2.0))
+    assert torch.count_nonzero(output[61:]) == 0
 
 
 def test_minimax_h3_initializes_sol_runtime_state() -> None:

--- a/tests/unit/ops/test_fp8_attention_smoothing.py
+++ b/tests/unit/ops/test_fp8_attention_smoothing.py
@@ -3,8 +3,11 @@ import torch
 import torch.nn.functional as F
 
 from telefuser.ops.fp8_attention import (
+    _quantize_fp8_qkv_sm90,
+    _sequence_mean,
     apply_fp8_attention_output_correction,
     dequantize_fp8_per_channel,
+    merge_fp8_attention_prefix,
     quantize_fp8_qkv_smoothed,
 )
 
@@ -52,6 +55,32 @@ def test_fp8_value_bias_correction_restores_original_sequence_mean_on_h100() -> 
 
 
 @pytest.mark.gpu
+def test_fused_kv_statistics_match_separate_reductions_on_h100() -> None:
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (9, 0):
+        pytest.skip("FP8 attention smoothing kernel test requires H100")
+    torch.manual_seed(1)
+    shape = (1, 130, 2, 128)
+    query = torch.randn(shape, device="cuda", dtype=torch.bfloat16)
+    key = torch.randn_like(query)
+    value = torch.randn_like(query)
+    key_mean = _sequence_mean(key)
+    value_mean = _sequence_mean(value)
+    expected = _quantize_fp8_qkv_sm90(query, key, value, k_mean=key_mean, v_mean=value_mean)
+    expected_correction = (value_mean - _sequence_mean(expected[2]) * expected[5]).unsqueeze(1).contiguous()
+
+    *actual, actual_correction = quantize_fp8_qkv_smoothed(
+        query,
+        key,
+        value,
+        smoothing="kv",
+        correct_v_bias=True,
+    )
+
+    assert all(torch.equal(before, after) for before, after in zip(expected, actual, strict=True))
+    assert torch.equal(expected_correction, actual_correction)
+
+
+@pytest.mark.gpu
 def test_fp8_output_correction_matches_fp32_add_without_allocation_on_h100() -> None:
     if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (9, 0):
         pytest.skip("FP8 attention correction kernel test requires H100")
@@ -64,6 +93,22 @@ def test_fp8_output_correction_matches_fp32_add_without_allocation_on_h100() -> 
     actual = apply_fp8_attention_output_correction(output, correction)
 
     assert actual.data_ptr() == pointer
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+@pytest.mark.gpu
+def test_fused_prefix_merge_matches_correction_then_cat_on_h100() -> None:
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (9, 0):
+        pytest.skip("FP8 attention prefix merge kernel test requires H100")
+    torch.manual_seed(2)
+    output = torch.randn((1, 130, 2, 128), device="cuda", dtype=torch.bfloat16)
+    prefix = torch.randn((1, 17, 2, 128), device="cuda", dtype=torch.bfloat16)
+    correction = torch.randn((1, 1, 2, 128), device="cuda", dtype=torch.float32)
+    corrected_suffix = (output[:, prefix.shape[1] :].float() + correction).to(output.dtype)
+    expected = torch.cat((prefix, corrected_suffix), dim=1)
+
+    actual = merge_fp8_attention_prefix(prefix, output, correction)
+
     torch.testing.assert_close(actual, expected, atol=0, rtol=0)
 
 

--- a/tests/unit/ops/test_fp8_attention_smoothing.py
+++ b/tests/unit/ops/test_fp8_attention_smoothing.py
@@ -1,0 +1,74 @@
+import pytest
+import torch
+import torch.nn.functional as F
+
+from telefuser.ops.fp8_attention import (
+    apply_fp8_attention_output_correction,
+    dequantize_fp8_per_channel,
+    quantize_fp8_qkv_smoothed,
+)
+
+
+def test_kv_sequence_mean_smoothing_is_attention_equivalent() -> None:
+    torch.manual_seed(0)
+    query = torch.randn(1, 3, 7, 8)
+    key = torch.randn_like(query)
+    value = torch.randn_like(query)
+    key_mean = key.mean(dim=2, keepdim=True)
+    value_mean = value.mean(dim=2, keepdim=True)
+
+    reference = F.scaled_dot_product_attention(query, key, value)
+    smoothed = F.scaled_dot_product_attention(query, key - key_mean, value - value_mean) + value_mean
+
+    torch.testing.assert_close(smoothed, reference, atol=2e-6, rtol=2e-6)
+
+
+@pytest.mark.gpu
+def test_fp8_value_bias_correction_restores_original_sequence_mean_on_h100() -> None:
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (9, 0):
+        pytest.skip("FP8 attention smoothing kernel test requires H100")
+    torch.manual_seed(0)
+    shape = (1, 130, 2, 128)
+    query = torch.randn(shape, device="cuda", dtype=torch.bfloat16)
+    key = torch.randn_like(query)
+    value = torch.randn_like(query)
+
+    _, _, value_fp8, _, _, value_scale, correction = quantize_fp8_qkv_smoothed(
+        query,
+        key,
+        value,
+        smoothing="kv",
+        correct_v_bias=True,
+    )
+
+    assert correction is not None
+    restored = dequantize_fp8_per_channel(value_fp8, value_scale, torch.float32) + correction
+    torch.testing.assert_close(
+        restored.mean(dim=1),
+        value.float().mean(dim=1),
+        atol=2e-6,
+        rtol=2e-6,
+    )
+
+
+@pytest.mark.gpu
+def test_fp8_output_correction_matches_fp32_add_without_allocation_on_h100() -> None:
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (9, 0):
+        pytest.skip("FP8 attention correction kernel test requires H100")
+    torch.manual_seed(0)
+    output = torch.randn((1, 130, 2, 128), device="cuda", dtype=torch.bfloat16)
+    correction = torch.randn((1, 1, 2, 128), device="cuda", dtype=torch.float32)
+    expected = (output.float() + correction).to(output.dtype)
+    pointer = output.data_ptr()
+
+    actual = apply_fp8_attention_output_correction(output, correction)
+
+    assert actual.data_ptr() == pointer
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+def test_value_bias_correction_requires_value_smoothing() -> None:
+    query = torch.randn(1, 64, 1, 128)
+
+    with pytest.raises(ValueError, match="requires smoothing='kv'"):
+        quantize_fp8_qkv_smoothed(query, query, query, smoothing="k", correct_v_bias=True)

--- a/tests/unit/ops/test_sol_attention.py
+++ b/tests/unit/ops/test_sol_attention.py
@@ -27,6 +27,22 @@ def test_sol_attention_config_defaults_and_validation() -> None:
         AttentionConfig.sol_attention(threshold_type="unknown")
     with pytest.raises(ValueError, match="KV splits"):
         AttentionConfig.sol_attention(kv_splits=3)
+    with pytest.raises(ValueError, match="smoothing"):
+        AttentionConfig.sol_attention(sol_fp8_smoothing="q")
+    with pytest.raises(ValueError, match="V bias correction"):
+        AttentionConfig.sol_attention(sol_fp8_smoothing="k", sol_fp8_v_bias_correction=True)
+
+
+def test_sol_attention_config_accepts_fp8_quality_profile() -> None:
+    config = AttentionConfig.sol_attention(
+        sol_fp8=True,
+        sol_fp8_smoothing="kv",
+        sol_fp8_v_bias_correction=True,
+    )
+
+    assert config.sparse_config is not None
+    assert config.sparse_config.sol_fp8_smoothing == "kv"
+    assert config.sparse_config.sol_fp8_v_bias_correction is True
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/ops/test_sol_attention.py
+++ b/tests/unit/ops/test_sol_attention.py
@@ -14,6 +14,9 @@ def test_sol_attention_config_defaults_and_validation() -> None:
 
     assert config.attn_impl is AttnImplType.SOL_ATTN
     assert config.is_sparse()
+    assert config.sparse_config is not None
+    assert config.sparse_config.sol_fp8_smoothing == "kv"
+    assert config.sparse_config.sol_fp8_v_bias_correction is True
     assert config.sparse_config == SparseAttentionConfig(
         sparse_impl="sol",
         dense_timesteps=10,
@@ -21,6 +24,8 @@ def test_sol_attention_config_defaults_and_validation() -> None:
         sol_tau=1.0,
         sol_threshold_type="diag",
         sol_kv_splits="auto",
+        sol_fp8_smoothing="kv",
+        sol_fp8_v_bias_correction=True,
     )
 
     with pytest.raises(ValueError, match="threshold type"):
@@ -33,7 +38,7 @@ def test_sol_attention_config_defaults_and_validation() -> None:
         AttentionConfig.sol_attention(sol_fp8_smoothing="k", sol_fp8_v_bias_correction=True)
 
 
-def test_sol_attention_config_accepts_fp8_quality_profile() -> None:
+def test_sol_attention_config_accepts_explicit_fp8_quality_profile() -> None:
     config = AttentionConfig.sol_attention(
         sol_fp8=True,
         sol_fp8_smoothing="kv",

--- a/tests/unit/pipelines/minimax_h3/test_examples.py
+++ b/tests/unit/pipelines/minimax_h3/test_examples.py
@@ -146,6 +146,8 @@ def test_standard_get_pipeline_forwards_parallel_runtime_options(monkeypatch: py
                 "sol_threshold_type": "exact",
                 "sol_fp8_layer_start": 0,
                 "sol_fp8_layer_end": None,
+                "sol_fp8_smoothing": "kv",
+                "sol_fp8_v_bias_correction": True,
                 "feature_cache_config": FeatureCacheConfig(
                     enabled=True,
                     model_type="MiniMax-H3-Base",
@@ -264,6 +266,8 @@ def test_standard_example_forwards_fp8_sol_configuration(monkeypatch: pytest.Mon
         sol_threshold_type="diag",
         sol_fp8_layer_start=2,
         sol_fp8_layer_end=40,
+        sol_fp8_smoothing="k",
+        sol_fp8_v_bias_correction=False,
         quantization="tf-kernel-fp8",
     )
 
@@ -277,6 +281,8 @@ def test_standard_example_forwards_fp8_sol_configuration(monkeypatch: pytest.Mon
     assert options["sol_threshold_type"] == "diag"
     assert options["sol_fp8_layer_start"] == 2
     assert options["sol_fp8_layer_end"] == 40
+    assert options["sol_fp8_smoothing"] == "k"
+    assert options["sol_fp8_v_bias_correction"] is False
     assert options["quantization"] == "tf-kernel-fp8"
 
 

--- a/tools/validation/benchmark_minimax_h3_fp8_sol_sp.py
+++ b/tools/validation/benchmark_minimax_h3_fp8_sol_sp.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Benchmark matched four-GPU MiniMax H3 baseline and FP8 Sol profiles."""
+"""Benchmark matched MiniMax H3 baseline and FP8 Sol profiles."""
 
 from __future__ import annotations
 
 import argparse
 import gc
 import json
+import os
 import subprocess
 import threading
 import time
@@ -28,7 +29,7 @@ def _package_version(name: str) -> str | None:
         return None
 
 
-def _device_memory_mib() -> list[int]:
+def _device_memory_mib(device_indices: list[int]) -> list[int]:
     output = subprocess.run(
         [
             "nvidia-smi",
@@ -43,15 +44,25 @@ def _device_memory_mib() -> list[int]:
     for line in output.splitlines():
         index, used_mib = (int(value.strip()) for value in line.split(","))
         values[index] = used_mib
-    return [values[index] for index in range(4)]
+    return [values[index] for index in device_indices]
 
 
-def _sample_device_memory(stop: threading.Event, peaks_mib: list[int]) -> None:
+def _sample_device_memory(stop: threading.Event, peaks_mib: list[int], device_indices: list[int]) -> None:
     while not stop.is_set():
-        current = _device_memory_mib()
+        current = _device_memory_mib(device_indices)
         for index, used_mib in enumerate(current):
             peaks_mib[index] = max(peaks_mib[index], used_mib)
         stop.wait(0.1)
+
+
+def _physical_device_indices(gpu_num: int) -> list[int]:
+    visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if visible:
+        indices = [int(value.strip()) for value in visible.split(",") if value.strip()]
+        if len(indices) < gpu_num:
+            raise ValueError("CUDA_VISIBLE_DEVICES exposes fewer GPUs than --gpu-num")
+        return indices[:gpu_num]
+    return list(range(gpu_num))
 
 
 def _generate(pipeline: object, args: argparse.Namespace) -> MiniMaxH3Generation:
@@ -78,6 +89,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--model-root", default=PPL_CONFIG["model_root"])
     parser.add_argument("--profile", choices=("baseline", "optimized"), required=True)
+    parser.add_argument("--gpu-num", type=int, choices=(1, 2, 4), default=1)
     parser.add_argument("--prompt", default=PPL_CONFIG["prompt"])
     parser.add_argument("--duration", type=float, default=5.0)
     parser.add_argument("--steps", type=int, default=50)
@@ -89,6 +101,12 @@ def main() -> None:
     parser.add_argument("--sol-threshold-type", choices=("exact", "diag"), default="exact")
     parser.add_argument("--sol-fp8-layer-start", type=int, default=0)
     parser.add_argument("--sol-fp8-layer-end", type=int)
+    parser.add_argument("--sol-fp8-smoothing", choices=("none", "k", "kv"), default="kv")
+    parser.add_argument(
+        "--sol-fp8-v-bias-correction",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+    )
     parser.add_argument("--no-warmup", action="store_true")
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--metrics-json", type=Path)
@@ -97,7 +115,7 @@ def main() -> None:
     optimized = args.profile == "optimized"
     load_started = time.perf_counter()
     pipeline = get_pipeline(
-        4,
+        args.gpu_num,
         args.model_root,
         num_inference_steps=args.steps,
         enable_fsdp=False,
@@ -110,6 +128,8 @@ def main() -> None:
         sol_threshold_type=args.sol_threshold_type,
         sol_fp8_layer_start=args.sol_fp8_layer_start,
         sol_fp8_layer_end=args.sol_fp8_layer_end,
+        sol_fp8_smoothing=args.sol_fp8_smoothing,
+        sol_fp8_v_bias_correction=args.sol_fp8_v_bias_correction,
         quantization="tf-kernel-fp8" if optimized else None,
     )
     load_seconds = time.perf_counter() - load_started
@@ -123,10 +143,15 @@ def main() -> None:
             del warmup
             gc.collect()
 
-        resident_memory_mib = _device_memory_mib()
+        device_indices = _physical_device_indices(args.gpu_num)
+        resident_memory_mib = _device_memory_mib(device_indices)
         peaks_mib = resident_memory_mib.copy()
         stop_sampling = threading.Event()
-        sampler = threading.Thread(target=_sample_device_memory, args=(stop_sampling, peaks_mib), daemon=True)
+        sampler = threading.Thread(
+            target=_sample_device_memory,
+            args=(stop_sampling, peaks_mib, device_indices),
+            daemon=True,
+        )
         sampler.start()
         try:
             generation_started = time.perf_counter()
@@ -147,7 +172,11 @@ def main() -> None:
     report = {
         "schema_version": 1,
         "profile": args.profile,
-        "parallelism": {"world_size": 4, "ulysses_degree": 2, "tp_degree": 2},
+        "parallelism": {
+            "world_size": args.gpu_num,
+            "ulysses_degree": args.gpu_num // 2 if args.gpu_num == 4 else args.gpu_num,
+            "tp_degree": 2 if args.gpu_num == 4 else 1,
+        },
         "attention": "SOL_ATTN" if optimized else "FLASH_ATTN_4",
         "linear_quantization": "tf-kernel-fp8" if optimized else None,
         "sol": (
@@ -159,6 +188,8 @@ def main() -> None:
                 "threshold_type": args.sol_threshold_type,
                 "fp8_layer_start": args.sol_fp8_layer_start,
                 "fp8_layer_end": args.sol_fp8_layer_end,
+                "smoothing": args.sol_fp8_smoothing,
+                "v_bias_correction": args.sol_fp8_v_bias_correction,
             }
             if optimized
             else None


### PR DESCRIPTION
## Summary

Follow up on #35 by improving MiniMax-H3 FP8 Sol-Attn quality with **attention-equivalent K/V sequence-mean smoothing**.

On the H100 MiniMax-H3, the final profile reduces attention-output MSE by **8.18%** versus unsmoothed FP8 Sol, remains **39.4% faster** than BF16, and uses **42.6% less peak allocated GPU memory**.

## Changes

- Centralize K in FP32 before E4M3 quantization
- Centralize V, restore its sequence mean after attention
- Fuse exact K/V statistics into one Triton reduction
- Merge BF16 dense-prefix replacement and sparse-output correction in one output pass
- Enable KV smoothing and V-bias correction by default in AttentionConfig.sol_attention; the standard MiniMax-H3 example no longer needs dedicated quality flags, while the validation benchmark keeps explicit ablation overrides.

This is attention smoothing, not SmoothQuant, where no scale is migrated between Linear activations and weights.

## MiniMax-H3: Unsmoothed vs Smoothed FP8 Sol

**Workload**: 1 x H100 80GB, no TP/SP, FL2VA T2VA 1344x768, 4 seconds / 107 decoded frames at 24 fps, 50 denoising steps, seed 0, exact Sol threshold, 10 dense steps, 2 dense layers, cold processes without warm-up, and MP4 serialization excluded from generation timing. Each FP8 profile was measured twice.

**Prompt**:

> Steam rises from the ramen while the family talks in the background.

### Performance overview

![MiniMax-H3 FP8 Sol attention smoothing performance](https://github.com/user-attachments/assets/30af484d-5e29-452c-a3b9-c8f4960d4d69)

- The final smoothed profile is 39.4% faster and uses 42.6% less peak allocated memory than BF16.
- Against unsmoothed FP8 Sol, exact smoothing adds 2.16% denoising time and costs 2.11% throughput, with unchanged peak allocated memory, while improving the generation quality as the following.

## Generated Output Comparison

![Matched frame comparison for BF16 and FP8 Sol outputs](https://github.com/user-attachments/assets/d6a59b6a-83e9-4c01-963b-55390aa49798)

**BF16 Linear + FlashAttention 4**

https://github.com/user-attachments/assets/74dc0819-70f5-4122-90fd-66cdb8317c16

**FP8 Linear + FP8 Sol, no smoothing**

https://github.com/user-attachments/assets/04939f60-cf11-4b29-9f33-5940d8a5f1e8

**FP8 Linear + FP8 Sol, KV smoothing + V correction**

https://github.com/user-attachments/assets/221aa0f5-a0b6-4826-a6cb-1e238b3a8152

**Quantitative analysis**, against the same-seed BF16 output:

| Profile | Frame cosine | PSNR | SSIM mean / min | Audio cosine | SI-SDR | Log-spectral distance |
|---|---:|---:|---:|---:|---:|---:|
| FP8 Sol, no smoothing | 0.87488 | 14.695 dB | 0.5464 / 0.5151 | **0.55217** | **-3.579 dB** | **12.484 dB** |
| FP8 Sol, KV smoothing + V correction | **0.87729** | **14.800 dB** | **0.5659 / 0.5382** | 0.53450 | -3.980 dB | 12.522 dB |

Smoothing improves every reported video metric.

## Smooth Attention Kernel Accuracy

**Measurement setup**:
- Real post-QK-norm, post-RoPE Q/K/V were captured from the first active Sol layer at live shape `(1, 32626, 56, 128)`
- Covers heads 0-3 over the complete 32,626-token K/V context
- Attention-output error uses 64 evenly spaced query positions and FP32 dense-attention math

| Boundary | Unsmoothed MSE | Smoothed MSE | Benefit |
|---|---:|---:|---:|
| quanted K | 9.380e-4 | 7.349e-4 | **21.65%** |
| dequanted V | 1.647e-2 | 1.611e-2 | 2.17% |
| dequanted V's mean | 1.044e-6 | 2.561e-14 | **>99.99999%** |
| attention output (against dense) | 7.034e-4 | 6.459e-4 | **8.18%** |

Dense-attention output cosine improves from 0.999403 to 0.999452, relative L2 error from 0.03455 to 0.03311, and SQNR from 29.23 to 29.60 dB. Q is intentionally unchanged by smoothing.
## Testing

```bash
ruff check <PR-scoped files>
ruff format --check <PR-scoped files>
git diff --check
# All checks passed

python -m pytest -q -m "not gpu" \
  tests/unit/models/test_minimax_h3_dit.py \
  tests/unit/ops/test_fp8_attention_smoothing.py \
  tests/unit/ops/test_sol_attention.py \
  tests/unit/pipelines/minimax_h3/test_examples.py
# 76 passed, 8 deselected

python -m pytest -q -m gpu \
  tests/unit/models/test_minimax_h3_dit.py \
  tests/unit/ops/test_fp8_attention_smoothing.py \
  tests/unit/ops/test_sol_attention.py \
  tests/unit/pipelines/minimax_h3/test_examples.py
# 8 passed, 76 deselected on one H100

python scripts/docs/prepare_cookbook.py
# Passed
```

GitHub CI also passes lint, build, server tests, and unit tests on Python 3.10, 3.11, and 3.12.

## Architecture Support

- Native FP8 Sol and fused smoothing kernels: NVIDIA Hopper SM90.
- Single-GPU MiniMax-H3: validated in this PR.
- Pure Ulysses and MiniMax-H3 TP + Ulysses: compatibility retained from #35.
- Fused Ulysses + FlashAttention 4 path: retained for dense attention.
- Ring and Ulysses-Ring: dense fallback retained.
- Wan FP8 Sol behavior: unchanged.
