### PR TITLE
[FEATURE] Run Wan2.2 pipelines on Ascend NPU

### DIFF
--- a/examples/wan_video/wan22_t2v_5b.py
+++ b/examples/wan_video/wan22_t2v_5b.py
@@ -17,6 +17,7 @@ from telefuser.pipelines.wan_video.wan22_ti2v import (
     Wan22TI2VPipeline,
     Wan22TI2VPipelineConfig,
 )
+from telefuser.platforms import current_platform
 from telefuser.utils.utils import get_example_name
 from telefuser.utils.video import get_target_video_size_from_ratio, save_video
 
@@ -80,7 +81,7 @@ def get_pipeline(parallelism: int = 1, model_root: str = PPL_CONFIG["model_root"
     )
 
     # Create pipeline
-    pipe = Wan22TI2VPipeline(device="cuda", torch_dtype=torch.bfloat16)
+    pipe = Wan22TI2VPipeline(device=current_platform.device_type, torch_dtype=torch.bfloat16)
 
     # Configure pipeline
     pipe_config = Wan22TI2VPipelineConfig()

--- a/telefuser/distributed/device_mesh.py
+++ b/telefuser/distributed/device_mesh.py
@@ -13,10 +13,11 @@ import torch.distributed as dist
 from torch.distributed.device_mesh import DeviceMesh
 
 from telefuser.core.config import ParallelConfig
+from telefuser.platforms import current_platform
 from telefuser.utils.logging import logger
 
 
-def create_device_mesh_from_config(parallel_config: ParallelConfig, device_type: str = "cuda") -> DeviceMesh:
+def create_device_mesh_from_config(parallel_config: ParallelConfig, device_type: str | None = None) -> DeviceMesh:
     """Create PyTorch DeviceMesh from ParallelConfig.
 
     Mesh dimensions are built in order: DP -> CFG -> SP (ring, ulysses) -> PP -> TP
@@ -24,11 +25,13 @@ def create_device_mesh_from_config(parallel_config: ParallelConfig, device_type:
 
     Args:
         parallel_config: Parallel configuration with degrees for each dimension
-        device_type: Device type ("cuda" or "cpu")
+        device_type: Device type ("cuda", "npu", or "cpu"); defaults to the current platform's device type
 
     Returns:
         PyTorch DeviceMesh instance with named dimensions
     """
+    if device_type is None:
+        device_type = current_platform.device_type
     _validate_parallel_config(parallel_config)
 
     sp_degree = parallel_config.sp_ulysses_degree * parallel_config.sp_ring_degree

--- a/telefuser/distributed/pp_comm.py
+++ b/telefuser/distributed/pp_comm.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import torch
 import torch.distributed as dist
 
+from telefuser.platforms import current_platform
 from telefuser.utils.logging import logger
 
 
@@ -107,7 +108,7 @@ class PipelineP2PComm:
         if buffer is None:
             if shape is None:
                 raise ValueError("Either buffer or shape must be provided")
-            buffer = torch.empty(shape, dtype=torch.float16, device="cuda")
+            buffer = torch.empty(shape, dtype=torch.float16, device=current_platform.device_type)
 
         buffer = buffer.contiguous()
         if async_op:
@@ -266,7 +267,7 @@ class PipelineP2PComm:
         if shape is None:
             raise ValueError("recv_latent: shape must be provided")
 
-        buffer = torch.empty(shape, dtype=dtype, device="cuda")
+        buffer = torch.empty(shape, dtype=dtype, device=current_platform.device_type)
         buffer = buffer.contiguous()
         work = dist.irecv(buffer, self.recv_src, group=self._process_group)
         work.wait()
@@ -300,7 +301,7 @@ class PipelineP2PComm:
         if self.is_first_stage:
             raise RuntimeError("recv_latent_async: First stage has no previous stage to receive from")
 
-        buffer = torch.empty(shape, dtype=dtype, device="cuda")
+        buffer = torch.empty(shape, dtype=dtype, device=current_platform.device_type)
         buffer = buffer.contiguous()
         work = dist.irecv(buffer, self.recv_src, group=self._process_group)
         return buffer, work

--- a/telefuser/distributed/vae_spatial.py
+++ b/telefuser/distributed/vae_spatial.py
@@ -128,7 +128,11 @@ def _spatial_causal_conv3d_forward(
     if any(padding):
         tensor = F.pad(tensor, padding)
     tensor = _exchange_height_halo(module, tensor, module._height_halo_size)
-    tensor = tensor.contiguous(memory_format=torch.channels_last_3d)
+    if tensor.device.type == "cuda":
+        tensor = tensor.contiguous(memory_format=torch.channels_last_3d)
+    else:
+        # channels_last_3d activations are only supported by cuDNN; NPU/CPU require standard contiguous.
+        tensor = tensor.contiguous()
     return F.conv3d(
         tensor,
         module.weight,

--- a/telefuser/kernel/triton/fp8_attention.py
+++ b/telefuser/kernel/triton/fp8_attention.py
@@ -1,0 +1,119 @@
+"""Fused block-scaled FP8 Q/K/V quantization Triton kernels."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _quantize_qkv_fp8_stage1(
+    q,
+    k,
+    v,
+    q_out,
+    k_out,
+    q_scale,
+    k_scale,
+    v_scale,
+    tokens: tl.constexpr,
+    heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    block: tl.constexpr,
+):
+    block_idx = tl.program_id(0)
+    batch_head = tl.program_id(1)
+    batch = batch_head // heads
+    head = batch_head % heads
+    token_offsets = block_idx * block + tl.arange(0, block)
+    dim_offsets = tl.arange(0, head_dim)
+    valid = token_offsets < tokens
+    offsets = ((batch * tokens + token_offsets[:, None]) * heads + head) * head_dim + dim_offsets[None, :]
+    q_values = tl.load(q + offsets, mask=valid[:, None], other=0.0).to(tl.float32)
+    k_values = tl.load(k + offsets, mask=valid[:, None], other=0.0).to(tl.float32)
+    v_values = tl.load(v + offsets, mask=valid[:, None], other=0.0).to(tl.float32)
+
+    q_s = tl.maximum(tl.max(tl.max(tl.abs(q_values), axis=1), axis=0), 1.0e-6) / 448.0
+    k_s = tl.maximum(tl.max(tl.max(tl.abs(k_values), axis=1), axis=0), 1.0e-6) / 448.0
+    scale_offset = (batch * tl.cdiv(tokens, block) + block_idx) * heads + head
+    tl.store(q_scale + scale_offset, q_s)
+    tl.store(k_scale + scale_offset, k_s)
+    tl.store(q_out + offsets, q_values / q_s, mask=valid[:, None])
+    tl.store(k_out + offsets, k_values / k_s, mask=valid[:, None])
+
+    v_s = tl.max(tl.abs(v_values), axis=0) / 448.0
+    v_scale_offsets = (batch * heads + head) * head_dim + dim_offsets
+    tl.atomic_max(v_scale + v_scale_offsets, v_s)
+
+
+@triton.jit
+def _quantize_qkv_fp8_stage2_v(
+    v,
+    v_out,
+    v_scale,
+    tokens: tl.constexpr,
+    heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    block: tl.constexpr,
+):
+    block_idx = tl.program_id(0)
+    batch_head = tl.program_id(1)
+    batch = batch_head // heads
+    head = batch_head % heads
+    token_offsets = block_idx * block + tl.arange(0, block)
+    dim_offsets = tl.arange(0, head_dim)
+    valid = token_offsets < tokens
+    input_offsets = ((batch * tokens + token_offsets[:, None]) * heads + head) * head_dim + dim_offsets[None, :]
+    output_offsets = ((batch * heads + head) * head_dim + dim_offsets[None, :]) * tokens + token_offsets[:, None]
+    scale_offsets = (batch * heads + head) * head_dim + dim_offsets
+    scale = tl.maximum(tl.load(v_scale + scale_offsets), 1.0e-6 / 448.0)
+    values = tl.load(v + input_offsets, mask=valid[:, None], other=0.0).to(tl.float32)
+    tl.store(v_out + output_offsets, values / scale[None, :], mask=valid[:, None])
+
+
+def quantize_fp8_qkv_triton(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    block_size: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Launch the fused Q/K/V quantization kernels on validated CUDA inputs."""
+    batch, tokens, heads, head_dim = q.shape
+    blocks = triton.cdiv(tokens, block_size)
+    q_out = torch.empty(q.shape, device=q.device, dtype=torch.float8_e4m3fn)
+    k_out = torch.empty_like(q_out)
+    v_storage = torch.empty((batch, heads, head_dim, tokens), device=q.device, dtype=torch.float8_e4m3fn)
+    q_scale = torch.empty((batch, blocks, heads), device=q.device, dtype=torch.float32)
+    k_scale = torch.ones_like(q_scale)
+    v_scale = torch.zeros((batch, heads, head_dim), device=q.device, dtype=torch.float32)
+    grid = (blocks, batch * heads)
+    _quantize_qkv_fp8_stage1[grid](
+        q,
+        k,
+        v,
+        q_out,
+        k_out,
+        q_scale,
+        k_scale,
+        v_scale,
+        tokens,
+        heads,
+        head_dim,
+        block_size,
+        num_warps=8,
+        num_stages=1,
+    )
+    _quantize_qkv_fp8_stage2_v[grid](
+        v,
+        v_storage,
+        v_scale,
+        tokens,
+        heads,
+        head_dim,
+        block_size,
+        num_warps=8,
+        num_stages=1,
+    )
+    v_out = v_storage.permute(0, 3, 1, 2)
+    return q_out, k_out, v_out, q_scale, k_scale, v_scale

--- a/telefuser/models/wan_video_vae.py
+++ b/telefuser/models/wan_video_vae.py
@@ -119,7 +119,11 @@ class CausalConv3d(nn.Conv3d):
             x = torch.cat([cache_x, x], dim=2)
             padding[4] -= cache_x.shape[2]
         x = F.pad(x, padding)
-        x = x.contiguous(memory_format=torch.channels_last_3d)
+        if x.device.type == "cuda":
+            x = x.contiguous(memory_format=torch.channels_last_3d)
+        else:
+            # channels_last_3d activations are only supported by cuDNN; NPU/CPU require standard contiguous.
+            x = x.contiguous()
         return super().forward(x)
 
 

--- a/telefuser/ops/fp8_attention.py
+++ b/telefuser/ops/fp8_attention.py
@@ -4,75 +4,8 @@ from __future__ import annotations
 
 import torch
 import torch.nn.functional as F
-import triton
-import triton.language as tl
 
 FP8_ATTENTION_BLOCK_SIZE = 64
-
-
-@triton.jit
-def _quantize_qkv_fp8_stage1(
-    q,
-    k,
-    v,
-    q_out,
-    k_out,
-    q_scale,
-    k_scale,
-    v_scale,
-    tokens: tl.constexpr,
-    heads: tl.constexpr,
-    head_dim: tl.constexpr,
-    block: tl.constexpr,
-):
-    block_idx = tl.program_id(0)
-    batch_head = tl.program_id(1)
-    batch = batch_head // heads
-    head = batch_head % heads
-    token_offsets = block_idx * block + tl.arange(0, block)
-    dim_offsets = tl.arange(0, head_dim)
-    valid = token_offsets < tokens
-    offsets = ((batch * tokens + token_offsets[:, None]) * heads + head) * head_dim + dim_offsets[None, :]
-    q_values = tl.load(q + offsets, mask=valid[:, None], other=0.0).to(tl.float32)
-    k_values = tl.load(k + offsets, mask=valid[:, None], other=0.0).to(tl.float32)
-    v_values = tl.load(v + offsets, mask=valid[:, None], other=0.0).to(tl.float32)
-
-    q_s = tl.maximum(tl.max(tl.max(tl.abs(q_values), axis=1), axis=0), 1.0e-6) / 448.0
-    k_s = tl.maximum(tl.max(tl.max(tl.abs(k_values), axis=1), axis=0), 1.0e-6) / 448.0
-    scale_offset = (batch * tl.cdiv(tokens, block) + block_idx) * heads + head
-    tl.store(q_scale + scale_offset, q_s)
-    tl.store(k_scale + scale_offset, k_s)
-    tl.store(q_out + offsets, q_values / q_s, mask=valid[:, None])
-    tl.store(k_out + offsets, k_values / k_s, mask=valid[:, None])
-
-    v_s = tl.max(tl.abs(v_values), axis=0) / 448.0
-    v_scale_offsets = (batch * heads + head) * head_dim + dim_offsets
-    tl.atomic_max(v_scale + v_scale_offsets, v_s)
-
-
-@triton.jit
-def _quantize_qkv_fp8_stage2_v(
-    v,
-    v_out,
-    v_scale,
-    tokens: tl.constexpr,
-    heads: tl.constexpr,
-    head_dim: tl.constexpr,
-    block: tl.constexpr,
-):
-    block_idx = tl.program_id(0)
-    batch_head = tl.program_id(1)
-    batch = batch_head // heads
-    head = batch_head % heads
-    token_offsets = block_idx * block + tl.arange(0, block)
-    dim_offsets = tl.arange(0, head_dim)
-    valid = token_offsets < tokens
-    input_offsets = ((batch * tokens + token_offsets[:, None]) * heads + head) * head_dim + dim_offsets[None, :]
-    output_offsets = ((batch * heads + head) * head_dim + dim_offsets[None, :]) * tokens + token_offsets[:, None]
-    scale_offsets = (batch * heads + head) * head_dim + dim_offsets
-    scale = tl.maximum(tl.load(v_scale + scale_offsets), 1.0e-6 / 448.0)
-    values = tl.load(v + input_offsets, mask=valid[:, None], other=0.0).to(tl.float32)
-    tl.store(v_out + output_offsets, values / scale[None, :], mask=valid[:, None])
 
 
 def quantize_fp8_qkv(
@@ -86,46 +19,11 @@ def quantize_fp8_qkv(
         raise ValueError("q, k, and v must share shape [B, T, H, D]")
     if not (q.is_cuda and q.is_contiguous() and k.is_contiguous() and v.is_contiguous()):
         raise ValueError("fused FP8 QKV quantization requires contiguous CUDA tensors")
-    batch, tokens, heads, head_dim = q.shape
-    if head_dim != 128:
+    if q.shape[-1] != 128:
         raise ValueError("fused FP8 QKV quantization requires head dimension 128")
-    blocks = triton.cdiv(tokens, FP8_ATTENTION_BLOCK_SIZE)
-    q_out = torch.empty(q.shape, device=q.device, dtype=torch.float8_e4m3fn)
-    k_out = torch.empty_like(q_out)
-    v_storage = torch.empty((batch, heads, head_dim, tokens), device=q.device, dtype=torch.float8_e4m3fn)
-    q_scale = torch.empty((batch, blocks, heads), device=q.device, dtype=torch.float32)
-    k_scale = torch.ones_like(q_scale)
-    v_scale = torch.zeros((batch, heads, head_dim), device=q.device, dtype=torch.float32)
-    grid = (blocks, batch * heads)
-    _quantize_qkv_fp8_stage1[grid](
-        q,
-        k,
-        v,
-        q_out,
-        k_out,
-        q_scale,
-        k_scale,
-        v_scale,
-        tokens,
-        heads,
-        head_dim,
-        FP8_ATTENTION_BLOCK_SIZE,
-        num_warps=8,
-        num_stages=1,
-    )
-    _quantize_qkv_fp8_stage2_v[grid](
-        v,
-        v_storage,
-        v_scale,
-        tokens,
-        heads,
-        head_dim,
-        FP8_ATTENTION_BLOCK_SIZE,
-        num_warps=8,
-        num_stages=1,
-    )
-    v_out = v_storage.permute(0, 3, 1, 2)
-    return q_out, k_out, v_out, q_scale, k_scale, v_scale
+    from telefuser.kernel.triton.fp8_attention import quantize_fp8_qkv_triton
+
+    return quantize_fp8_qkv_triton(q, k, v, FP8_ATTENTION_BLOCK_SIZE)
 
 
 def quantize_fp8_per_block(

--- a/telefuser/worker/parallel_worker.py
+++ b/telefuser/worker/parallel_worker.py
@@ -323,9 +323,6 @@ class ParallelWorker:
             reason = f"{method_name} failed: {result}"
             self._mark_failed(reason)
             raise RuntimeError(f"ParallelWorker:{self.name} {reason}") from result
-        if current_platform.device_type != "cuda":
-            # CPU-marshalled queue results move back to the stage device for downstream consumers.
-            result = to_device(result, self._stage.device)
         return result
 
     def enable_metrics(self, registry: Any | None = None) -> None:

--- a/telefuser/worker/parallel_worker.py
+++ b/telefuser/worker/parallel_worker.py
@@ -158,6 +158,9 @@ def _worker_loop(
                 y = tensor_output_channel.send(y)
             # Always output results when world_size=1
             if world_size == 1 or rank == 0:
+                if current_platform.device_type != "cuda":
+                    # Queue transport without reliable device IPC: marshal results through CPU.
+                    y = to_device(y, "cpu")
                 queue_out.put(y)
     except Exception as e:
         import traceback
@@ -206,7 +209,8 @@ class ParallelWorker:
             self.device_ids = list(range(self.world_size))
 
         self.name: str = f"Parallel Worker {stage.name}"
-        self.queue_with_cpu: bool = parallel_config.queue_with_cpu
+        # Queue transport requires CPU marshalling on platforms without reliable device IPC (e.g. NPU).
+        self.queue_with_cpu: bool = parallel_config.queue_with_cpu or current_platform.device_type != "cuda"
         self.timeout: int = parallel_config.timeout
         self._lifecycle_lock = threading.Lock()
         self._failed = False
@@ -319,6 +323,9 @@ class ParallelWorker:
             reason = f"{method_name} failed: {result}"
             self._mark_failed(reason)
             raise RuntimeError(f"ParallelWorker:{self.name} {reason}") from result
+        if current_platform.device_type != "cuda":
+            # CPU-marshalled queue results move back to the stage device for downstream consumers.
+            result = to_device(result, self._stage.device)
         return result
 
     def enable_metrics(self, registry: Any | None = None) -> None:

--- a/tests/unit/distributed/test_pp_comm.py
+++ b/tests/unit/distributed/test_pp_comm.py
@@ -7,9 +7,13 @@ import torch
 import torch.distributed as dist
 
 from telefuser.distributed.pp_comm import PipelineP2PComm
+from telefuser.platforms import current_platform
 
 # Skip if distributed not available
 HAS_DISTRIBUTED = dist.is_available()
+
+# Buffers follow the detected platform so the suite runs on CUDA, NPU, and CPU hosts alike.
+DEVICE = current_platform.device_type
 
 pytestmark = [
     pytest.mark.skipif(not HAS_DISTRIBUTED, reason="Distributed not available"),
@@ -56,7 +60,7 @@ class TestPipelineP2PCommMethods:
         """Test that send on last stage logs warning and returns None."""
         comm = PipelineP2PComm(None)  # Single GPU, is_last_stage=True
 
-        tensor = torch.randn(1, 10, 512, device="cuda")
+        tensor = torch.randn(1, 10, 512, device=DEVICE)
         result = comm.send(tensor)
 
         assert result is None
@@ -72,7 +76,7 @@ class TestPipelineP2PCommMethods:
         """Test send_recv on single GPU (no-op)."""
         comm = PipelineP2PComm(None)  # Single GPU
 
-        send_tensor = torch.randn(1, 10, 512, device="cuda")
+        send_tensor = torch.randn(1, 10, 512, device=DEVICE)
         result = comm.send_recv(send_tensor)
 
         # On single GPU, recv_buffer is None since there's no previous stage
@@ -114,7 +118,7 @@ class TestPipelineP2PCommMethods:
         """Test queue_send on last stage does nothing."""
         comm = PipelineP2PComm(None)  # is_last_stage=True
 
-        tensor = torch.randn(1, 10, 512, device="cuda")
+        tensor = torch.randn(1, 10, 512, device=DEVICE)
         comm.queue_send(tensor)
 
         assert len(comm._ops) == 0
@@ -123,7 +127,7 @@ class TestPipelineP2PCommMethods:
         """Test queue_recv on first stage does nothing."""
         comm = PipelineP2PComm(None)  # is_first_stage=True
 
-        buffer = torch.randn(1, 10, 512, device="cuda")
+        buffer = torch.randn(1, 10, 512, device=DEVICE)
         comm.queue_recv(buffer)
 
         assert len(comm._ops) == 0
@@ -152,7 +156,7 @@ class TestPipelineP2PCommLatentMethods:
         """Test send_latent on last stage returns early."""
         comm = PipelineP2PComm(None)  # is_last_stage=True
 
-        tensor = torch.randn(1, 10, 512, device="cuda")
+        tensor = torch.randn(1, 10, 512, device=DEVICE)
         # Should not raise, just return
         comm.send_latent(tensor)
 
@@ -182,7 +186,7 @@ class TestPipelineP2PCommLatentMethods:
         """Test send_latent_async on last stage returns None."""
         comm = PipelineP2PComm(None)  # is_last_stage=True
 
-        tensor = torch.randn(1, 10, 512, device="cuda")
+        tensor = torch.randn(1, 10, 512, device=DEVICE)
         result = comm.send_latent_async(tensor)
 
         assert result is None
@@ -248,7 +252,7 @@ class TestPipelineP2PCommIntegration:
 
         if comm.is_first_stage:
             # Send tensor to next stage
-            send_tensor = torch.ones(1, 10, 512, device="cuda") * comm.rank
+            send_tensor = torch.ones(1, 10, 512, device=DEVICE) * comm.rank
             comm.send_latent(send_tensor)
         elif comm.is_last_stage:
             # Receive tensor from previous stage


### PR DESCRIPTION
## Description

Enable the Wan2.2 pipelines to run on Ascend NPU, single-card and multi-card, with a minimal correctness-focused change set. All fixes reuse the existing platform architecture (`current_platform`, capability gates, `queue_with_cpu`); CUDA behavior is unchanged by construction — every new branch is gated on platform or tensor device type.

## Motivation

TeleFuser already ships a platform abstraction (`telefuser/platforms/`, `CustomOp.forward_npu`, `dist_backend="hccl"`), and the wan22 pipeline code itself is platform-clean. In practice, a handful of CUDA defaults outside that abstraction still prevented NPU execution: an unconditional `channels_last_3d` activation cast, a `"cuda"` device-mesh default, device-IPC-dependent worker queues, a hard `import triton`, and `"cuda"`-allocated P2P buffers. This PR removes those blockers.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] Other (please describe):

## Changes Made

- `models/wan_video_vae.py`, `distributed/vae_spatial.py`: gate activation-side `channels_last_3d` casts to CUDA tensors (weight-side conversion was already cuDNN-gated; NPU rejects that memory format with `ERR01007`).
- `distributed/device_mesh.py`: `create_device_mesh_from_config` defaults `device_type` to `current_platform.device_type` (12 of 14 call sites rely on the default; the `"cuda"` default crashed torch `DeviceMesh` on NPU hosts with `integer modulo by zero`). Explicit arguments keep working.
- `worker/parallel_worker.py`: enable the existing `queue_with_cpu` marshalling by default on non-CUDA platforms and mirror it on the result path (torch_npu cross-process tensor sharing raises `devptr INTERNAL ASSERT FAILED` when rebuilding queued NPU tensors). Worker dispatch already moves inputs to the local device, so the contract is unchanged; CUDA keeps direct device-queue transport.
- `ops/fp8_attention.py` → `kernel/triton/fp8_attention.py`: move the `@triton.jit` fused FP8 QKV kernels into `kernel/triton/` and import them lazily inside `quantize_fp8_qkv` after its existing CUDA-only validation, matching the established `ops -> kernel.triton` dispatch pattern. The wan_video / minimax DiT import chains no longer require triton to be installed.
- `distributed/pp_comm.py`, `tests/unit/distributed/test_pp_comm.py`: allocate P2P receive buffers on `current_platform.device_type` instead of hard-coded `"cuda"`, and parameterize the test tensor device so the suite runs on CUDA, NPU, and CPU hosts.
- `examples/wan_video/wan22_t2v_5b.py`: default the pipeline device to the detected platform so the example runs unmodified on CUDA and NPU hosts (resolves to `"cuda"` on CUDA as before).

## Testing

- [x] Unit tests pass (`pytest tests/`)
- [x] Manual testing performed
- [ ] Benchmarks added/updated (if applicable)

Test commands:
```bash
# CPU host (triton not installed): import chain and unit tests
python -c "from telefuser.pipelines.wan_video.wan22_ti2v import Wan22TI2VPipeline"
pytest tests/unit/distributed/test_pp_comm.py tests/unit/worker -q
pytest tests/unit -q

# Ascend 910B (CANN 8.2, torch 2.9.0 + torch_npu 2.9.0.post1, triton not installed)
python examples/wan_video/wan22_t2v_5b.py --gpu_num 1   # unmodified example; device auto-detected
python examples/wan_video/wan22_t2v_5b.py --gpu_num 4   # cfg_degree=2 x sp_ulysses_degree=2 over hccl
```

Results on Ascend 910B: single-card Wan2.2-TI2V-5B text-to-video succeeds end to end (bf16, `TORCH_SDPA`, unipc; semantically correct output); the `MODEL_CPU_OFFLOAD` variant is bit-identical to the no-offload run (same seed). 4-card denoising completes with workers exiting cleanly, using the existing eager ulysses fallbacks. `tests/unit/distributed/test_pp_comm.py` passes 12/12 (previously 6 device-related failures on non-CUDA hosts), and `tests/unit/models/test_wan_video_sol_attention.py` passes with CUDA-only cases skipped. CUDA hosts execute identical code paths as before (device-mesh default resolves to `"cuda"`, `queue_with_cpu` stays opt-in, activation casts and buffer devices are unchanged on CUDA).

## Checklist

- [x] Code follows the project's coding standards (`ruff`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files` — ruff + ruff-format; also covered by the lint CI job)
- [x] All tests pass (`pytest tests/`)
- [x] New tests added for new functionality (platform-parameterized `test_pp_comm.py`)
- [x] Documentation updated (docstrings; no README/AGENTS impact — a platform guide is planned as follow-up)
- [x] Commit messages are clear and descriptive
- [x] PR title follows the convention: `[TYPE] Brief description`

## Related Issues

N/A

## Additional Notes

Performance parity is intentionally out of scope: with everything on eager fallbacks, multi-card currently shows limited speedup over single-card on NPU (per-layer eager all_to_all over hccl and the serial VAE decode dominate). A follow-up PR will address NPU-optimized paths behind the existing dispatch points. `offload/async_offload.py` remains CUDA-only (auto-disabled elsewhere); Wan2.2 A14B (MoE dual-DiT) shares these code paths but has not been exercised on NPU hardware yet.

## GPU Architecture Support

- [ ] SM80 (Ampere, Ada Lovelace)
- [ ] SM90 (Hopper H100)
- [ ] SM100+ (Blackwell)

No CUDA kernels are added or modified — the fused FP8 QKV kernels are moved verbatim and their SM90 targeting is unchanged — so no architecture box is checked.

**Device support added by this PR: Ascend NPU** (verified on Atlas 910B, CANN 8.2, torch 2.9.0 + torch_npu 2.9.0.post1, via the existing `telefuser/platforms/` NPU platform). CUDA devices are unaffected.

## Performance Impact

None on CUDA (all new branches are platform- or device-gated; CUDA executes the previous code paths).

**Ascend 910B baseline established by this PR** — Atlas 910B (8× 910B2 64 GB), CANN 8.2, torch 2.9.0 + torch_npu 2.9.0.post1. All numbers are produced by the **unmodified example** `examples/wan_video/wan22_t2v_5b.py` (bf16, `TORCH_SDPA`, unipc, **50 denoising steps**, `MODEL_CPU_OFFLOAD`, `cfg_scale=5.0` — i.e. two DiT forwards per denoising step; under cfg parallelism the two guidance branches run on separate ranks). Times are end-to-end generate (one-time init excluded); every row is reproducible with the exact command shown:

| Workload | Command | 1 card | 2 cards (cfg=2) | 4 cards (cfg=2 × ulysses=2) |
|---|---|---|---|---|
| 480p, 121 frames | `python examples/wan_video/wan22_t2v_5b.py --gpu_num N` | 180.9 s | 120.8 s (1.50×) | **87.0 s (2.08×)** |
| 720p, 121 frames | `python examples/wan_video/wan22_t2v_5b.py --gpu_num N --resolution 720p` | 477.8 s | — | **173.9 s (2.75×)** |

Measured stage split at 480p / 121 frames (from run-log timestamps):

| Stage | 1 card | 2 cards | 4 cards |
|---|---|---|---|
| Text encode (incl. weight onload) | ≈10.6 s | ≈9 s | ≈8.8 s |
| Denoise, 50 steps | **136 s** (2.73 s/step) | **67 s** (**2.03×**) | **40 s** (**3.4×**) |
| DiT weight staging + VAE decode + result return | ≈34 s | ≈45 s | ≈38 s |
