### PR TITLE
[PERF] Ascend NPU: MindIE-SD attention backend and VAE-parallel enablement

### DIFF
--- a/docs/en/attention.md
+++ b/docs/en/attention.md
@@ -24,6 +24,7 @@ class AttnImplType(Enum):
     FLASH_ATTN_2 = auto()
     FLASH_ATTN_3 = auto()
     FLASH_ATTN_4 = auto()  # For Hopper (SM90) and Blackwell (SM100+) GPUs
+    MINDIE_ATTN = auto()  # Ascend NPU, requires the optional mindiesd package
     SAGE_ATTN_2_8_8 = auto()
     SAGE_ATTN_2_8_16 = auto()
     SAGE_ATTN_2_8_8_SM90 = auto()

--- a/telefuser/core/config.py
+++ b/telefuser/core/config.py
@@ -127,6 +127,7 @@ class AttnImplType(Enum):
     FLASH_ATTN_2 = auto()
     FLASH_ATTN_3 = auto()
     FLASH_ATTN_4 = auto()
+    MINDIE_ATTN = auto()
     # Sparse attention implementations
     RADIAL_ATTN = auto()  # Radial attention for video generation
     LOCAL_SPARSE_ATTN = auto()  # Local window sparse attention

--- a/telefuser/models/wan22_video_vae.py
+++ b/telefuser/models/wan22_video_vae.py
@@ -1393,7 +1393,11 @@ class Wan22VideoVAE(BaseModel):
         if self.parallelism > 1 and dist.is_initialized():
             # tiled=True → tile_dist, tiled=False → 2d_split
             method = "tile_dist" if tiled else "2d_split"
-            hidden_states_tensor = torch.stack(hidden_states)
+            # The stage passes a batched [B, C, T, H, W] tensor; lists of per-video tensors are stacked.
+            if isinstance(hidden_states, torch.Tensor):
+                hidden_states_tensor = hidden_states
+            else:
+                hidden_states_tensor = torch.stack(hidden_states)
             return self.decode_parallel(hidden_states_tensor, device, method=method)
 
         # Single GPU processing

--- a/telefuser/ops/attention/attention_impl.py
+++ b/telefuser/ops/attention/attention_impl.py
@@ -1,7 +1,7 @@
 """Unified attention implementation with dense and sparse support.
 
 Supports multiple attention implementations:
-- Dense: TORCH_SDPA, TORCH_CUDNN, FLASH_ATTN_2/3/4, SAGE_ATTN variants, SPARGE_ATTN
+- Dense: TORCH_SDPA, TORCH_CUDNN, FLASH_ATTN_2/3/4, SAGE_ATTN variants, SPARGE_ATTN, MINDIE_ATTN (Ascend NPU)
 - Sparse: RADIAL_ATTN, LOCAL_SPARSE_ATTN, SOL_ATTN
 
 Note: Attention functions are decorated with @torch.compiler.disable because:
@@ -31,6 +31,7 @@ from telefuser.ops.attention.backends import (
     FLASH_ATTN_2_AVAILABLE,
     FLASH_ATTN_3_AVAILABLE,
     FLASH_ATTN_4_AVAILABLE,
+    MINDIE_ATTN_AVAILABLE,
     SAGE_ATTN_AVAILABLE,
     SDPA_AVAILABLE,
     SOL_ATTN_AVAILABLE,
@@ -39,6 +40,7 @@ from telefuser.ops.attention.backends import (
     flash_attn4,
     flash_attn4_varlen,
     get_lse_fallback_impl,
+    mindie_attn,
     sageattention,
     sdpa_attn_cudnn,
     sol_attn,
@@ -272,7 +274,7 @@ def attention(
     # - Flash Attention expects BSND (NHD) layout
     # - PyTorch SDPA variants expect BNSD (HND) layout
     # - SageAttention can accept both via tensor_layout parameter
-    BNSD_IMPLS = {AttnImplType.TORCH_CUDNN, AttnImplType.TORCH_SDPA, AttnImplType.SPARGE_ATTN}
+    BNSD_IMPLS = {AttnImplType.TORCH_CUDNN, AttnImplType.TORCH_SDPA, AttnImplType.SPARGE_ATTN, AttnImplType.MINDIE_ATTN}
 
     # Track current layout after potential conversions
     current_layout = input_layout
@@ -346,6 +348,10 @@ def attention(
             output, lse, _ = result
         else:
             output = result
+
+    # MindIE-SD attention (Ascend NPU)
+    elif sequence_lengths is None and attn_impl == AttnImplType.MINDIE_ATTN and MINDIE_ATTN_AVAILABLE:
+        output = mindie_attn(q, k, v, attn_mask=attn_mask, scale=scale, is_causal=is_causal)
 
     # PyTorch SDPA
     elif sequence_lengths is None and attn_impl == AttnImplType.TORCH_CUDNN and SDPA_AVAILABLE:

--- a/telefuser/ops/attention/backends.py
+++ b/telefuser/ops/attention/backends.py
@@ -13,6 +13,7 @@ from typing import Callable
 import torch
 from torch import Tensor
 
+from telefuser.platforms import current_platform
 from telefuser.utils.logging import logger
 
 # Availability flags
@@ -24,6 +25,7 @@ SAGE_ATTN_AVAILABLE = False
 SPARGE_ATTN_AVAILABLE = False
 FLASHINFER_AVAILABLE = False
 SOL_ATTN_AVAILABLE = False
+MINDIE_ATTN_AVAILABLE = False
 
 # Backend function references (populated on successful import)
 flash_attn2: Callable | None = None
@@ -34,6 +36,7 @@ sageattention: object | None = None
 spas_sage2_attn_meansim_cuda: Callable | None = None
 flashinfer: object | None = None
 sol_attn: Callable | None = None
+mindiesd_attention_forward: Callable | None = None
 
 
 def _try_import_flash_attn() -> None:
@@ -162,12 +165,48 @@ def _try_import_sol_attn() -> None:
 
 
 # Initialize all backends
+def _try_import_mindie_attn() -> None:
+    """Import the optional MindIE-SD attention backend (Ascend NPU only)."""
+    global MINDIE_ATTN_AVAILABLE, mindiesd_attention_forward
+
+    MINDIE_ATTN_AVAILABLE = False
+    mindiesd_attention_forward = None
+    if current_platform.device_type != "npu":
+        return
+    try:
+        if importlib.util.find_spec("mindiesd") is None:
+            return
+        from mindiesd import attention_forward
+    except (ModuleNotFoundError, ImportError) as error:
+        logger.debug("MindIE-SD attention backend unavailable: %s", error)
+        return
+    mindiesd_attention_forward = attention_forward
+    MINDIE_ATTN_AVAILABLE = True
+    logger.debug("MindIE-SD attention available")
+
+
+def mindie_attn(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    *,
+    attn_mask: Tensor | None = None,
+    scale: float | None = None,
+    is_causal: bool = False,
+) -> Tensor:
+    """MindIE-SD attention wrapper for BNSD inputs on Ascend NPU."""
+    if is_causal:
+        raise ValueError("MINDIE_ATTN does not support causal attention")
+    return mindiesd_attention_forward(q, k, v, attn_mask=attn_mask, scale=scale, head_first=True)
+
+
 _try_import_flash_attn()
 _try_import_sdpa()
 _try_import_sage_attn()
 _try_import_sparge_attn()
 _try_import_flashinfer()
 _try_import_sol_attn()
+_try_import_mindie_attn()
 
 
 def supports_return_lse(attn_impl: str) -> bool:
@@ -234,6 +273,7 @@ __all__ = [
     "SPARGE_ATTN_AVAILABLE",
     "FLASHINFER_AVAILABLE",
     "SOL_ATTN_AVAILABLE",
+    "MINDIE_ATTN_AVAILABLE",
     "flash_attn2",
     "flash_attn3",
     "flash_attn4",
@@ -245,4 +285,5 @@ __all__ = [
     "get_lse_fallback_impl",
     "sdpa_attn_cudnn",
     "sparge_attn",
+    "mindie_attn",
 ]

--- a/telefuser/worker/parallel_worker.py
+++ b/telefuser/worker/parallel_worker.py
@@ -7,6 +7,7 @@ with proper process group initialization.
 from __future__ import annotations
 
 import gc
+import itertools
 import os
 import signal
 import threading
@@ -34,6 +35,10 @@ if TYPE_CHECKING:
 
 
 _DISCARD_TENSOR_REFS = "__telefuser_discard_tensor_refs__"
+
+# Each concurrent worker group needs a distinct HCCL socket range on NPU hosts;
+# overlapping ranges fail comm init with EJ0003 (port already bound).
+_hccl_group_counter = itertools.count()
 
 
 def to_device(data: Any, device: str | torch.device) -> Any:
@@ -65,6 +70,7 @@ def _worker_loop(
     master_port: int,
     tensor_output_channel: WorkerTensorChannel | None = None,
     tensor_input_channels: tuple[WorkerTensorChannel, ...] = (),
+    hccl_if_base_port: int | None = None,
 ) -> None:
     """Worker process main loop.
 
@@ -89,6 +95,11 @@ def _worker_loop(
             os.environ["WORLD_SIZE"] = str(world_size)
             os.environ["MASTER_ADDR"] = "localhost"
             os.environ["MASTER_PORT"] = str(master_port)
+            if hccl_if_base_port is not None:
+                # Give each worker group a distinct host-side HCCL socket base;
+                # overlapping ranges fail comm init with EJ0003 when several
+                # groups share the same devices (e.g. denoise + VAE workers).
+                os.environ["HCCL_IF_BASE_PORT"] = str(hccl_if_base_port)
             device_ids = parallel_config.device_ids
             device_id = rank
             if device_ids is not None:
@@ -253,6 +264,7 @@ class ParallelWorker:
                 master_port,
                 self.tensor_output_channel,
                 self.tensor_input_channels,
+                60000 + 1024 * next(_hccl_group_counter) if current_platform.device_type == "npu" else None,
             ),
             nprocs=self.world_size,
             join=False,

--- a/tests/unit/ops/test_attention_backends.py
+++ b/tests/unit/ops/test_attention_backends.py
@@ -269,3 +269,19 @@ def test_ring_config_converts_fallback_name() -> None:
     assert result.attn_impl is AttnImplType.SAGE_ATTN_2_8_8_SM90
     assert result.scale == 0.125
     assert result.is_causal is True
+
+
+def test_mindie_attn_dispatch_converts_to_bnsd_and_back() -> None:
+    q = torch.randn(1, 3, 2, 4)
+    forward = MagicMock(side_effect=lambda q_, k_, v_, **kwargs: q_)
+
+    with (
+        patch.object(attention_impl, "MINDIE_ATTN_AVAILABLE", True),
+        patch.object(backends, "mindiesd_attention_forward", forward),
+    ):
+        output = attention_impl.attention(q, q, q, attn_impl=attention_impl.AttnImplType.MINDIE_ATTN)
+
+    assert output.shape == q.shape
+    called_q = forward.call_args.args[0]
+    assert called_q.shape == (1, 2, 3, 4)
+    assert forward.call_args.kwargs == {"attn_mask": None, "scale": None, "head_first": True}


### PR DESCRIPTION
## Description

Ascend NPU acceleration on top of #42, in two parts:

1. An optional **MindIE-SD attention backend** (`AttnImplType.MINDIE_ATTN`) that routes dense attention through `mindiesd.attention_forward` (auto-tuned Ascend kernels including LaserAttention), with measured end-to-end gains of **1.10–1.18×** over the #42 baseline on compute-dominated configurations.
2. Two fixes that make spatially parallel VAE decode usable: repair the `enable_vae_parallel` input contract for the Wan2.2 48-channel VAE (currently broken on every platform), and isolate HCCL socket ranges per worker group so concurrent groups can coexist on NPU hosts.

Default behavior is unchanged on every platform: the backend is strictly opt-in, and the VAE/HCCL fixes are inert outside `enable_vae_parallel` / multi-group NPU runs.

## Motivation

- #42 established the Ascend baseline and showed denoising is the dominant, well-scaling cost; its attention runs on torch_npu SDPA. `mindiesd` (open-sourced MindIE-SD) provides faster Ascend attention kernels behind a stable API — measured **1.29–1.53×** over SDPA at wan-typical shapes.
- `Wan22VideoVAE.decode`'s parallel branch calls `torch.stack` on its input, assuming a list, but `VAEStage.decode_video` passes a batched tensor; any `enable_vae_parallel` run of a Wan2.2-VAE pipeline fails with `TypeError` today, on CUDA as well as NPU.
- Concurrent worker groups on NPU collide on HCCL's default data-plane socket range (`EJ0003`); a distinct per-group `HCCL_IF_BASE_PORT` (mirroring the existing per-group `MASTER_PORT`) removes the collision.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Other (please describe):

## Changes Made

- `telefuser/core/config.py`, `telefuser/ops/attention/backends.py`, `telefuser/ops/attention/attention_impl.py`, `docs/en/attention.md`: add `AttnImplType.MINDIE_ATTN` with a sageattention-style availability probe (optional `mindiesd` import, NPU platform only), a BNSD dispatch branch, and documentation. This intentionally adds **one public enum value**; no dependency is added to `pyproject.toml` (optional import, like sageattention).
- `tests/unit/ops/test_attention_backends.py`: mock-based dispatch unit test for the new backend (runs on CPU CI).
- `telefuser/models/wan22_video_vae.py`: normalize `decode`'s input before the parallel-branch `torch.stack` — batched tensors pass through, lists are stacked as before.
- `telefuser/worker/parallel_worker.py`: allocate a distinct `HCCL_IF_BASE_PORT` per spawned worker group on NPU platforms; other platforms untouched.

## Testing

- [x] Unit tests pass (`pytest tests/`)
- [x] Manual testing performed
- [x] Benchmarks added/updated (if applicable)

Test commands:
```bash
pytest tests/unit -q
# backend selected via the existing config surface:
#   pipe_config.dit_config.attention_config = AttentionConfig.dense_attention(AttnImplType.MINDIE_ATTN)
python examples/wan_video/wan22_t2v_5b.py --gpu_num 1 --resolution 720p
python examples/wan_video/wan22_t2v_5b.py --gpu_num 4 --resolution 720p
```

- `tests/unit/ops/test_attention_backends.py` 11 passed (includes the new dispatch test; mock-based, platform-independent); full `tests/unit` green.
- Numerical parity: `MINDIE_ATTN` output is bit-identical to `TORCH_SDPA` at probed BNSD bf16 shapes on Atlas 910B.
- Multi-process path verified: the enum travels through the pickled stage config, so 4-card denoising workers select the backend correctly.
- Single-group 4-card regression with the per-group HCCL base port applied: timing at parity with the #42 baseline.
- VAE-parallel on our particular Ascend host still stops inside torch_npu's cross-process device layer after these fixes (driver/firmware mismatch, unrelated to this change — see Additional Notes); the input fix itself is platform-independent.

## Performance Impact

Measured against the **#42 baseline** (same host, same unmodified example, same commands; Atlas 910B 8× 910B2, CANN 8.2, torch 2.9.0 + torch_npu 2.9.0.post1, 50 denoising steps, `MODEL_CPU_OFFLOAD`):

| Workload | Cards | #42 baseline (`TORCH_SDPA`) | This PR (`MINDIE_ATTN`) | Speedup |
|---|---|---|---|---|
| 480p, 121 frames | 1 | 180.9 s | 162.6 s | **1.11×** |
| 480p, 121 frames | 4 (cfg=2 × ulysses=2) | 87.0 s | 103.0 s | 0.84× — regression, see guidance |
| 720p, 121 frames | 1 | 477.8 s | 405.0 s | **1.18×** |
| 720p, 121 frames | 4 (cfg=2 × ulysses=2) | 173.9 s | 157.6 s | **1.10×** |

Kernel microbench (BNSD bf16, head_dim 128): `mindiesd` attention is **1.29–1.53×** faster than torch_npu SDPA across S = 12.5k–45.8k, at both 24 and 12 heads (the ulysses head-sharded shape).

Lossless stack (same task, same quality; configuration only): `MINDIE_ATTN` plus resident weights (`NO_CPU_OFFLOAD` instead of the example's `MODEL_CPU_OFFLOAD`) measures **407.6 s on 1 card (1.17×)** and **151.9 s on 4 cards (1.14×)** at 720p/121 frames. The weight-residency gain is visible at 4 cards (−5.7 s) and within run noise at 1 card.

For reference only (not part of this PR's performance claims): combining the above with the existing in-tree RIFE VFI stage (generate 61 frames, interpolate to 121) measures 193.1 s / 94.4 s — but that changes the generation itself (the model's temporal prior operates at half the frame rate and interpolation reconstructs the rest), so it is a quality trade-off that needs content-level motion validation rather than a lossless optimization.

Guidance: the backend is opt-in and recommended for compute-dominated configurations (single-card, and multi-card at high resolution / long schedules). The 480p 4-card regression persists even though the kernel itself is faster at exactly those shapes, which points at an interaction with the ulysses async-communication overlap when per-step compute is small; `TASK_QUEUE_ENABLE=2` does not recover it. Default `TORCH_SDPA` behavior is unchanged, and the VAE/HCCL fixes have no effect on standard single-group runs (verified at parity).

## Related Issues

Complements #42 (Ascend NPU enablement); all baseline numbers above are from #42's Performance Impact section. Independently mergeable.

## Additional Notes

- Why no new unit test for the VAE fix: constructing a `Wan22VideoVAE` requires full model weights and the parallel branch needs an initialized process group; the normalization is a two-line input guard exercised by the example path.
- On our Ascend host (driver 25.2.0 vs CANN 8.2, with repeated "driver and firmware packages do not match" warnings) full dual-worker-group execution still fails inside torch_npu's cross-process device layer after the HCCL port isolation; we validated up to communicator setup and expect driver-matched installs (and CUDA) to run the full path. Expected impact once VAE decode parallelizes, from #42's measured serial sections: ≈2.08× → ≈2.6× (480p) and ≈2.75× → ≈3.3× (720p) on 4 cards.
- `mindiesd` is available from PyPI (`pip install mindiesd`); when absent or off-NPU, the probe leaves the backend unavailable and nothing changes.

## GPU Architecture Support

- [ ] SM80 (Ampere, Ada Lovelace)
- [ ] SM90 (Hopper H100)
- [ ] SM100+ (Blackwell)

No CUDA kernels are added or modified. The new backend calls prebuilt `mindiesd` kernels on Ascend NPU only; CUDA behavior is unchanged.

## Checklist

- [x] Code follows the project's coding standards (`ruff`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files` — ruff + ruff-format; also covered by the lint CI job)
- [x] All tests pass (`pytest tests/`)
- [x] New tests added for new functionality (`test_attention_backends.py` dispatch test)
- [x] Documentation updated (`docs/en/attention.md`, docstrings)
- [x] Commit messages are clear and descriptive
- [x] PR title follows the convention: `[TYPE] Brief description`
